### PR TITLE
docs: harmonize accepted RFC governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation and governance
 
+- Added Cross-RFC terminology harmonization, Bridge dependency-direction clarification, execution-scoped tenant-context clarification, and telemetry finalization and scope-closure ordering clarification for accepted EvolvePHP 2 RFCs 0001-0006.
 - Added `AGENTS.md` as the mandatory workflow rule source for coding agents working in this repository.
 - Added EvolvePHP 1 legacy preservation documentation under `docs/history/`.
 - Added RFC 0001: EvolvePHP 2 Vision, Scope and Non-Goals.

--- a/docs/rfcs/0001-evolvephp-2-vision-and-scope.md
+++ b/docs/rfcs/0001-evolvephp-2-vision-and-scope.md
@@ -87,7 +87,9 @@ Teams should be able to introduce EvolvePHP without rewriting an existing Larave
 
 ### Modern Runtime Safety
 
-Request-scoped and tenant-scoped state must not leak across requests, workers or persistent runtime executions.
+Execution-scoped state, including request, message, job, user and tenant context, must not leak across executions or persistent-worker reuse.
+
+RFC 0005 defines application, execution and transient lifetimes. Tenant context may exist when supplied by an application. Tenant context belongs to execution scope, and RFC 0001 does not establish a separate tenant-scoped container. Multitenancy remains deferred.
 
 ### Standards Interoperability
 
@@ -170,9 +172,14 @@ Examples:
 - Telemetry exporter.
 - Authentication integration.
 - Developer tool.
-- Host framework bridge.
 
 Later RFCs will define exact lifecycle and dependency rules. RFC 0001 establishes vocabulary; it does not finalise implementation-level APIs.
+
+### Bridge Adapter
+
+A Bridge adapter is an integration-adapter category. Bridge and Plugin are not synonyms.
+
+A specific Bridge adapter may participate through approved registration or plugin lifecycle contracts. Participation in lifecycle does not automatically redefine the adapter as a plugin. RFC 0004 remains authoritative for Plugin terminology, and RFC 0006 remains authoritative for Bridge terminology.
 
 ## 8. PHP Support Policy
 
@@ -221,6 +228,17 @@ The host framework owns:
 
 EvolvePHP owns only the selected feature-module lifecycle.
 
+Policy summary:
+
+- The host owns the top-level process and browser-facing application boundary.
+- The host normally owns its existing session and identity-establishment infrastructure.
+- The host owns the outer routing and delegation decision.
+- Evolve validates translated identity assertions.
+- Evolve authorizes Evolve-owned operations.
+- Additional Evolve authentication or step-up validation must be explicit.
+- A delegated route or capability has one authoritative owner.
+- RFC 0006 remains authoritative for detailed authentication, authorization, route and session boundaries.
+
 ### Sidecar Or Separately Deployed Mode
 
 Sidecar or separately deployed mode is for:
@@ -240,7 +258,7 @@ In headless remote-module mode, the host application communicates through:
 - Integration events.
 - Future remote protocols where justified.
 
-Evolve Bridge is planned for the EvolvePHP 2.0 Beta direction, after stable core, HTTP, module and plugin contracts exist.
+Evolve Bridge is planned for the EvolvePHP 2.0 Beta direction, after stable core, HTTP, module and plugin contracts exist. RFC 0006 governs the Bridge architecture targeted toward Beta foundations.
 
 ## 10. EvolvePHP 2.0 Scope
 
@@ -283,6 +301,8 @@ The beta may include:
 - First-party reference modules.
 - Documentation and upgrade guidance.
 
+Beta does not promise every Bridge adapter or full advanced remote-module extraction.
+
 ### 2.0 Stable
 
 Stable requires:
@@ -314,6 +334,8 @@ EvolvePHP 2.1 candidates include mature persistent-runtime adapters, FrankenPHP 
 ### EvolvePHP 2.2 Candidates
 
 EvolvePHP 2.2 candidates include advanced service extraction, remote module adapters, outbox and inbox patterns, distributed command and query buses, cross-service workflow tooling, Kubernetes reference architecture, advanced autoscaling and service topology, and managed platform foundations. Kubernetes and advanced service extraction are not required for initial 2.0.
+
+Advanced service extraction, distributed workflow tooling and mature remote-module orchestration remain deferred unless a later RFC moves them.
 
 ## 12. Explicit Non-Goals
 

--- a/docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md
+++ b/docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md
@@ -231,12 +231,14 @@ EvolvePHP adopts this execution lifecycle:
 6. Handle application work
 7. Capture the primary outcome
 8. Run execution termination hooks
-9. Close execution-scoped resources
-10. Reset reusable application-lifetime participants
-11. Clear ambient context
-12. Finalize execution telemetry
-13. Decide whether the process is safe for reuse
-14. Return, acknowledge, reject or report the outcome
+9. Finish active execution telemetry
+10. Detach active trace, span and propagation context
+11. Close execution-scoped resources
+12. Reset reusable application-lifetime participants
+13. Clear any remaining ambient execution context
+14. Perform bounded export or flush using detached immutable telemetry data
+15. Decide whether the process is safe for reuse
+16. Return, acknowledge, reject or report the outcome
 ```
 
 Rules:
@@ -244,6 +246,8 @@ Rules:
 - Runtime adapters may need to adapt ordering around response transmission or queue acknowledgement.
 - Cleanup and reset must always run through a `finally`-equivalent path.
 - The original application outcome remains identifiable after cleanup.
+- Termination hooks may still generate telemetry before active telemetry is finalized.
+- Post-closure telemetry export or flush must operate only on detached data and must not reactivate the closed execution context.
 - A new execution must not start in the same worker until the previous execution reaches a terminal cleanup result, unless explicit concurrency isolation is implemented and proven.
 
 ## 10. Execution State Machine
@@ -311,8 +315,7 @@ Rules:
 ## 13. Tenant Isolation Boundary
 
 - RFC 0005 does not define EvolvePHP multitenancy.
-- When an application supplies tenant context, that context belongs to execution scope.
-- Tenant context belongs to execution scope when provided by the application.
+- Tenant context belongs to execution scope when supplied by an application.
 - A later execution without tenant context must not inherit one.
 - Tenant-aware connection selection, caches, configuration overlays and authorization must reset safely.
 - Application singletons must not retain a current tenant.
@@ -414,9 +417,11 @@ Rules:
 - Filesystem enumeration order must not determine reset order.
 - Arbitrary numeric reset priority is not the foundational mechanism.
 - Cleanup of resources created inside one scope should use reverse creation or acquisition order where practical.
-- Telemetry finalization must occur after the application work outcome is known.
+- Telemetry finalization must occur after the application work outcome and termination hooks are known.
+- Active trace, span and propagation context must detach before execution-scoped resources close.
 - Ambient execution context must be cleared before another execution becomes active.
-- The exact positioning of telemetry export may be refined by RFC 0007 without weakening isolation.
+- Post-closure telemetry export or flush must use detached immutable telemetry data only.
+- The exact positioning of telemetry APIs, spans, metrics, logs and exporters may be refined by RFC 0007 without weakening isolation.
 
 ## 21. Reset Contract Behaviour
 
@@ -546,14 +551,19 @@ advisory locks
 ## 29. Telemetry Context
 
 - Trace and span context belong to execution scope.
+- Active trace, span and propagation context must not survive execution-scope closure.
+- Termination hooks may still generate telemetry before active telemetry is finalized.
 - The active span must not survive execution closure.
 - Baggage and propagation context must clear.
+- Post-closure export or flush must operate only on detached data.
+- Export must not reactivate the closed execution context.
+- Export or flush must be bounded.
 - Telemetry export must not block worker cleanup indefinitely.
-- Exporter failure should not normally corrupt application state.
-- Telemetry reset failure that leaves active context uncertain must prevent worker reuse.
+- An exporter failure does not normally corrupt application state.
+- Failure to detach or clear active telemetry context prevents safe worker reuse.
 - Core remains independent of Observe.
 - Insight diagnostic batches must not merge unrelated executions.
-- Exact traces, metrics and logs belong to RFC 0007.
+- RFC 0007 may refine APIs, spans, metrics, logs and exporter placement without weakening isolation.
 
 ## 30. Output Buffers, Streams And Temporary Resources
 
@@ -616,7 +626,7 @@ A process may accept another execution only when:
 - Temporary resources released.
 - Reset participants completed.
 - Ambient context cleared.
-- Telemetry context finalized or safely detached.
+- Telemetry context finalized, active context detached and post-closure export limited to detached data.
 - No quarantine trigger exists.
 - Runtime adapter confirms safe reuse.
 
@@ -716,7 +726,7 @@ An enabled plugin failure during reset quarantines the worker.
 
 - Observe may create one root span or equivalent telemetry unit per execution.
 - Context propagation must remain execution-scoped.
-- Observe must clear active context.
+- Observe must clear active context before execution-scope closure.
 - Exporter delays must be bounded.
 - Observe must not be required for Core reset correctness.
 - Observe must not depend on Insight.

--- a/docs/rfcs/0006-evolve-bridge-and-incremental-modernisation.md
+++ b/docs/rfcs/0006-evolve-bridge-and-incremental-modernisation.md
@@ -264,7 +264,9 @@ Evolve\Bridge\Remote\
 
 - Contains stable generic Bridge contracts.
 - Generic Bridge contracts must not contain Laravel or Symfony types.
-- Depends inward on Evolve public contracts only.
+- Generic Bridge contracts contain no Laravel or Symfony types.
+- `bridge-contracts` depends on `evolvephp/contracts`.
+- `bridge-contracts` must not depend on Core or HTTP implementations.
 - Must remain small.
 - Must not become a duplicate Core package.
 
@@ -300,28 +302,36 @@ Not every conceptual package must ship in the first Bridge release.
 
 ## 12. Dependency Direction
 
-Accepted direction:
+RFC 0006 reaffirms RFC 0002's inward dependency direction and refines low-level Bridge edges without reversing RFC 0002.
 
-```text
-Evolve contracts/core/http
-          ^
-bridge-contracts
-          ^
-bridge-psr
-bridge-laravel
-bridge-symfony
-bridge-remote
-```
+Accepted package dependency policy:
 
-Depending on implementation needs, adapter packages may depend directly on necessary public Evolve packages, but dependencies remain inward.
+- `evolvephp/bridge-contracts` depends on `evolvephp/contracts`.
+- `evolvephp/bridge-psr` depends on `evolvephp/bridge-contracts`, selected public Evolve packages and selected PSR packages.
+- `evolvephp/bridge-laravel` depends on `evolvephp/bridge-contracts`, selected public Evolve packages and supported Laravel packages.
+- `evolvephp/bridge-symfony` depends on `evolvephp/bridge-contracts`, selected public Evolve packages and supported Symfony packages.
+- `evolvephp/bridge-remote` depends on `evolvephp/bridge-contracts`, selected public Evolve packages and selected transport or interoperability packages.
+
+Rules:
+
+- `bridge-contracts` depends on `evolvephp/contracts`, not Core or HTTP implementations.
+- Adapter packages may depend directly on selected public Evolve packages where required.
+- Adapter packages do not automatically depend on every Evolve package shown above.
+- Core and HTTP never depend on host-specific Bridge adapters.
+- Generic Bridge contracts contain no Laravel or Symfony types.
+- RFC 0002's inward dependency direction remains authoritative.
+- RFC 0006 refines low-level Bridge edges without reversing RFC 0002.
 
 Forbidden:
 
 ```text
 core -> bridge-*
+http -> bridge-*
 http -> bridge-laravel
 http -> bridge-symfony
 contracts -> host framework
+bridge-contracts -> core
+bridge-contracts -> http
 bridge-contracts -> Laravel
 bridge-contracts -> Symfony
 bridge-laravel -> application internals

--- a/tests/Documentation/EvolvePhp2RfcConsistencyTest.php
+++ b/tests/Documentation/EvolvePhp2RfcConsistencyTest.php
@@ -1,0 +1,215 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class EvolvePhp2RfcConsistencyTest extends TestCase
+{
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testAcceptedRfcsExistAndKeepDependencyChain(): void
+    {
+        $rfcs = array(
+            '0001' => 'docs/rfcs/0001-evolvephp-2-vision-and-scope.md',
+            '0002' => 'docs/rfcs/0002-terminology-package-boundaries-and-public-contracts.md',
+            '0003' => 'docs/rfcs/0003-php-versioning-compatibility-and-release-policy.md',
+            '0004' => 'docs/rfcs/0004-module-and-plugin-lifecycle.md',
+            '0005' => 'docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md',
+            '0006' => 'docs/rfcs/0006-evolve-bridge-and-incremental-modernisation.md',
+        );
+
+        foreach ($rfcs as $number => $path) {
+            $content = $this->readProjectFile($path);
+
+            $this->assertMatchesPattern('/#\s*RFC\s+' . $number . ':/i', $content);
+            $this->assertMatchesPattern('/Status:\s*Accepted/i', $content);
+            $this->assertMatchesPattern('/Superseded by:\s*None/i', $content);
+        }
+
+        $this->assertMatchesPattern('/Depends on:\s*RFC 0001/i', $this->readProjectFile($rfcs['0002']));
+        $this->assertMatchesPattern('/Depends on:\s*RFC 0001,\s*RFC 0002/i', $this->readProjectFile($rfcs['0003']));
+        $this->assertMatchesPattern('/Depends on:\s*RFC 0001,\s*RFC 0002,\s*RFC 0003/i', $this->readProjectFile($rfcs['0004']));
+        $this->assertMatchesPattern('/Depends on:\s*RFC 0001,\s*RFC 0002,\s*RFC 0003,\s*RFC 0004/i', $this->readProjectFile($rfcs['0005']));
+        $this->assertMatchesPattern('/Depends on:\s*RFC 0001,\s*RFC 0002,\s*RFC 0003,\s*RFC 0004,\s*RFC 0005/i', $this->readProjectFile($rfcs['0006']));
+    }
+
+    public function testRfc0001UsesRfc0005ExecutionScopeTerminologyForTenantContext(): void
+    {
+        $content = $this->readProjectFile('docs/rfcs/0001-evolvephp-2-vision-and-scope.md');
+
+        $this->assertMatchesPattern('/Execution-scoped state, including request, message, job, user and tenant context, must not leak across executions or persistent-worker reuse/i', $content);
+        $this->assertMatchesPattern('/RFC 0005 defines application, execution and transient lifetimes/i', $content);
+        $this->assertMatchesPattern('/Tenant context may exist when supplied by an application/i', $content);
+        $this->assertMatchesPattern('/Tenant context belongs to execution scope/i', $content);
+        $this->assertMatchesPattern('/RFC 0001 does not establish a separate tenant-scoped container/i', $content);
+        $this->assertMatchesPattern('/Multitenancy remains deferred/i', $content);
+        $this->assertDoesNotMatchPattern('/Request-scoped and tenant-scoped state/i', $content);
+    }
+
+    public function testRfc0001KeepsBridgeAndPluginTerminologySeparate(): void
+    {
+        $content = $this->readProjectFile('docs/rfcs/0001-evolvephp-2-vision-and-scope.md');
+
+        $this->assertMatchesPattern('/A Bridge adapter is an integration-adapter category/i', $content);
+        $this->assertMatchesPattern('/Bridge and Plugin are not synonyms/i', $content);
+        $this->assertMatchesPattern('/A specific Bridge adapter may participate through approved registration or plugin lifecycle contracts/i', $content);
+        $this->assertMatchesPattern('/Participation in lifecycle does not automatically redefine the adapter as a plugin/i', $content);
+        $this->assertMatchesPattern('/RFC 0004 remains authoritative for Plugin terminology/i', $content);
+        $this->assertMatchesPattern('/RFC 0006 remains authoritative for Bridge terminology/i', $content);
+        $this->assertDoesNotMatchPattern(
+            '/-\s*Host framework bridge\./i',
+            $this->extractSection($content, 'Module Versus Plugin Distinction')
+        );
+    }
+
+    public function testRfc0001EmbeddedOwnershipSummaryMatchesRfc0006(): void
+    {
+        $content = $this->readProjectFile('docs/rfcs/0001-evolvephp-2-vision-and-scope.md');
+
+        $this->assertMatchesPattern('/The host owns the top-level process and browser-facing application boundary/i', $content);
+        $this->assertMatchesPattern('/The host normally owns its existing session and identity-establishment infrastructure/i', $content);
+        $this->assertMatchesPattern('/The host owns the outer routing and delegation decision/i', $content);
+        $this->assertMatchesPattern('/Evolve validates translated identity assertions/i', $content);
+        $this->assertMatchesPattern('/Evolve authorizes Evolve-owned operations/i', $content);
+        $this->assertMatchesPattern('/Additional Evolve authentication or step-up validation must be explicit/i', $content);
+        $this->assertMatchesPattern('/A delegated route or capability has one authoritative owner/i', $content);
+        $this->assertMatchesPattern('/RFC 0006 remains authoritative for detailed authentication, authorization, route and session boundaries/i', $content);
+    }
+
+    public function testRfc0001DistinguishesBetaBridgeFoundationsFromAdvancedRemoteExtraction(): void
+    {
+        $content = $this->readProjectFile('docs/rfcs/0001-evolvephp-2-vision-and-scope.md');
+
+        $this->assertMatchesPattern('/RFC 0006 governs the Bridge architecture targeted toward Beta foundations/i', $content);
+        $this->assertMatchesPattern('/Beta does not promise every Bridge adapter or full advanced remote-module extraction/i', $content);
+        $this->assertMatchesPattern('/Advanced service extraction, distributed workflow tooling and mature remote-module orchestration remain deferred unless a later RFC moves them/i', $content);
+    }
+
+    public function testRfc0005TenantSectionHasOneNormativeTenantContextOwnershipStatement(): void
+    {
+        $section = $this->extractSection(
+            $this->readProjectFile('docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md'),
+            'Tenant Isolation Boundary'
+        );
+
+        $this->assertSame(
+            1,
+            preg_match_all('/tenant context.*belongs to execution scope/i', $section),
+            'Tenant context ownership should be stated once in the tenant isolation section.'
+        );
+        $this->assertMatchesPattern('/A later execution without tenant context must not inherit one/i', $section);
+        $this->assertMatchesPattern('/Application singletons must not retain a current tenant/i', $section);
+        $this->assertMatchesPattern('/Static current-tenant helpers are forbidden/i', $section);
+        $this->assertMatchesPattern('/tests must alternate tenant identifiers/i', $section);
+    }
+
+    public function testRfc0005OrdersTelemetryFinalizationBeforeScopeClosureAndDetachedExportAfterClosure(): void
+    {
+        $content = $this->readProjectFile('docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md');
+
+        $this->assertMatchesPattern('/Run execution termination hooks.*Finish active execution telemetry.*Detach active trace, span and propagation context.*Close execution-scoped resources.*Reset reusable application-lifetime participants.*Clear any remaining ambient execution context.*Perform bounded export or flush using detached immutable telemetry data.*Decide whether the process is safe for reuse/is', $content);
+        $this->assertMatchesPattern('/Active trace, span and propagation context must not survive execution-scope closure/i', $content);
+        $this->assertMatchesPattern('/Termination hooks may still generate telemetry before active telemetry is finalized/i', $content);
+        $this->assertMatchesPattern('/Post-closure export or flush must operate only on detached data/i', $content);
+        $this->assertMatchesPattern('/Export must not reactivate the closed execution context/i', $content);
+        $this->assertMatchesPattern('/Export or flush must be bounded/i', $content);
+        $this->assertMatchesPattern('/An exporter failure does not normally corrupt application state/i', $content);
+        $this->assertMatchesPattern('/Failure to detach or clear active telemetry context prevents safe worker reuse/i', $content);
+        $this->assertMatchesPattern('/RFC 0007 may refine APIs, spans, metrics, logs and exporter placement without weakening isolation/i', $content);
+        $this->assertMatchesPattern('/handler result or handler exception is the primary execution outcome/i', $content);
+        $this->assertMatchesPattern('/Cleanup failure must not erase the primary execution exception/i', $content);
+    }
+
+    public function testRfc0006BridgeDependencyDirectionIsUnambiguous(): void
+    {
+        $content = $this->readProjectFile('docs/rfcs/0006-evolve-bridge-and-incremental-modernisation.md');
+
+        $this->assertMatchesPattern('/`bridge-contracts` depends on `evolvephp\/contracts`/i', $content);
+        $this->assertMatchesPattern('/`bridge-contracts` must not depend on Core or HTTP implementations/i', $content);
+        $this->assertMatchesPattern('/Adapter packages may depend directly on selected public Evolve packages where required/i', $content);
+        $this->assertMatchesPattern('/Adapter packages do not automatically depend on every Evolve package shown/i', $content);
+        $this->assertMatchesPattern('/Core and HTTP never depend on host-specific Bridge adapters/i', $content);
+        $this->assertMatchesPattern('/Generic Bridge contracts contain no Laravel or Symfony types/i', $content);
+        $this->assertMatchesPattern('/RFC 0002.s inward dependency direction remains authoritative/i', $content);
+        $this->assertMatchesPattern('/RFC 0006 refines low-level Bridge edges without reversing RFC 0002/i', $content);
+        $this->assertDoesNotMatchPattern('/Evolve contracts\/core\/http\s*\R\s*\s*\^\s*\R\s*bridge-contracts/i', $content);
+    }
+
+    public function testAuthoritativeGovernanceResponsibilitiesRemainCrossReferenced(): void
+    {
+        $rfc1 = $this->readProjectFile('docs/rfcs/0001-evolvephp-2-vision-and-scope.md');
+        $rfc2 = $this->readProjectFile('docs/rfcs/0002-terminology-package-boundaries-and-public-contracts.md');
+        $rfc4 = $this->readProjectFile('docs/rfcs/0004-module-and-plugin-lifecycle.md');
+        $rfc5 = $this->readProjectFile('docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md');
+        $rfc6 = $this->readProjectFile('docs/rfcs/0006-evolve-bridge-and-incremental-modernisation.md');
+
+        $this->assertMatchesPattern('/RFC 0001 is authoritative for product scope and positioning/i', $rfc1);
+        $this->assertMatchesPattern('/RFC 0002 is authoritative for package and public API boundaries/i', $rfc2);
+        $this->assertMatchesPattern('/RFC 0004 is authoritative for module and plugin lifecycle behaviour/i', $rfc4);
+        $this->assertMatchesPattern('/RFC 0005 is authoritative for execution scope, reset and persistent-worker safety/i', $rfc5);
+        $this->assertMatchesPattern('/RFC 0006 is authoritative for Evolve Bridge and incremental-modernisation architecture/i', $rfc6);
+    }
+
+    public function testRfcsDoNotClaimTheRepairedArchitectureIsImplemented(): void
+    {
+        foreach ($this->rfcPaths() as $path) {
+            $content = $this->readProjectFile($path);
+
+            $this->assertMatchesPattern('/does not (?:claim|implement|create|publish|promise)|is not implemented|future policy|direction/i', $content);
+            $this->assertDoesNotMatchPattern('/\b(?:is|are) already implemented\b/i', $content);
+        }
+    }
+
+    public function testChangelogRecordsConsistencyRepair(): void
+    {
+        $content = $this->readProjectFile('CHANGELOG.md');
+
+        $this->assertMatchesPattern('/Cross-RFC terminology harmonization/i', $content);
+        $this->assertMatchesPattern('/Bridge dependency-direction clarification/i', $content);
+        $this->assertMatchesPattern('/execution-scoped tenant-context clarification/i', $content);
+        $this->assertMatchesPattern('/telemetry finalization and scope-closure ordering clarification/i', $content);
+    }
+
+    private function rfcPaths()
+    {
+        return array(
+            'docs/rfcs/0001-evolvephp-2-vision-and-scope.md',
+            'docs/rfcs/0002-terminology-package-boundaries-and-public-contracts.md',
+            'docs/rfcs/0003-php-versioning-compatibility-and-release-policy.md',
+            'docs/rfcs/0004-module-and-plugin-lifecycle.md',
+            'docs/rfcs/0005-request-scope-runtime-reset-and-persistent-worker-safety.md',
+            'docs/rfcs/0006-evolve-bridge-and-incremental-modernisation.md',
+        );
+    }
+
+    private function readProjectFile($path)
+    {
+        $fullPath = $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+        $this->assertFileExists($fullPath, $path . ' should exist before it is read.');
+
+        return file_get_contents($fullPath);
+    }
+
+    private function extractSection($content, $heading)
+    {
+        $pattern = '/^##\s+[0-9]+\. ' . preg_quote($heading, '/') . '\R(?P<section>.*?)(?=^##\s+[0-9]+\. |\z)/ms';
+
+        $this->assertSame(1, preg_match($pattern, $content, $matches), 'Section not found: ' . $heading);
+
+        return $matches['section'];
+    }
+
+    private function assertMatchesPattern($pattern, $content)
+    {
+        $this->assertSame(1, preg_match($pattern, $content), 'Failed asserting that content matches ' . $pattern);
+    }
+
+    private function assertDoesNotMatchPattern($pattern, $content)
+    {
+        $this->assertSame(0, preg_match($pattern, $content), 'Failed asserting that content does not match ' . $pattern);
+    }
+}


### PR DESCRIPTION
## Summary

- Harmonize terminology and ownership rules across accepted RFCs 0001 through 0006
- Clarify that tenant context belongs to execution scope rather than a separate foundational tenant scope
- Clarify that Bridge adapters and framework Plugins are distinct architectural categories
- Align RFC 0001 host, identity, authorization and route ownership summaries with RFC 0006
- Distinguish EvolvePHP 2.0 Beta Bridge foundations from advanced remote-module extraction and distributed orchestration
- Remove duplicate tenant-context ownership wording from RFC 0005
- Clarify telemetry finalization, context detachment, scope closure and bounded export ordering
- Replace RFC 0006's ambiguous Bridge dependency diagram with explicit package dependency rules
- Add a cross-RFC consistency documentation test
- Record the governance repair in the changelog

## Architectural outcome

- RFC 0001 remains authoritative for product scope and release direction
- RFC 0002 remains authoritative for package and public API boundaries
- RFC 0003 remains authoritative for compatibility, versioning and release policy
- RFC 0004 remains authoritative for application, module and plugin lifecycle
- RFC 0005 remains authoritative for execution scope, reset and persistent-worker safety
- RFC 0006 remains authoritative for Bridge integration and incremental modernisation

No accepted architecture decision was superseded or reversed.

## Validation

- Cross-RFC consistency suite passed: 11 tests, 126 assertions
- Complete documentation suite passed: 63 tests, 633 assertions
- Complete available Composer test suite passed: 63 tests, 633 assertions
- composer validate passed with the existing Composer version-field warning
- git diff --check passed

## Environment

- PHP 8.3.7
- PHPUnit 10.5.0
- Composer 2.7.6

PHP 8.3 execution validated documentation tests only and does not establish EvolvePHP 2 runtime compatibility.

PHPUnit 8 compatibility was not claimed.

No framework code, Bridge code, telemetry implementation, package, interface, dependency, Composer metadata, PHP requirement, CI workflow or legacy runtime source was changed.