### PR TITLE
build: add EvolvePHP 2 Composer workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /nbproject/*
 /vendor/*
 composer.lock
+!workspace/composer.lock
+/workspace/vendor/
 /logs/*
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation and governance
 
+- Added Phase 2.2 dedicated EvolvePHP 2 Composer workspace with local path-repository integration and explicit 2.0.x-dev package version mapping.
 - Added Phase 2.1 initial EvolvePHP 2 package skeleton boundaries for the accepted alpha package map.
 - Added Cross-RFC terminology harmonization, Bridge dependency-direction clarification, execution-scoped tenant-context clarification, and telemetry finalization and scope-closure ordering clarification for accepted EvolvePHP 2 RFCs 0001-0006.
 - Added `AGENTS.md` as the mandatory workflow rule source for coding agents working in this repository.

--- a/packages/README.md
+++ b/packages/README.md
@@ -48,6 +48,6 @@ The packages have not been installed or runtime-tested in this task.
 
 The current root Composer manifest remains the legacy EvolvePHP 1 harness temporarily. It still exists so current repository documentation and policy tests can run while EvolvePHP 2 repository structure is introduced separately.
 
-Phase 2.2 will establish the dedicated EvolvePHP 2 workspace Composer configuration.
+Phase 2.2 now provides the dedicated Composer workspace; this is the EvolvePHP 2 workspace Composer configuration for development. See `workspace/README.md` for package-resolution, lockfile and local solver-verification policy.
 
 Real PHP 8.4 and PHP 8.5 CI evidence is required before compatibility is claimed. Composer manifest validation under another local PHP version does not establish EvolvePHP 2 runtime compatibility.

--- a/tests/Architecture/EvolvePhp2WorkspaceComposerTest.php
+++ b/tests/Architecture/EvolvePhp2WorkspaceComposerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class EvolvePhp2WorkspaceComposerTest extends TestCase
+{
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testWorkspaceComposerManifestExistsAndContainsValidJson(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+
+        $this->assertSame('evolvephp/workspace', $manifest['name']);
+        $this->assertSame('project', $manifest['type']);
+        $this->assertSame('BSD-3-Clause', $manifest['license']);
+    }
+
+    public function testWorkspaceRepositoryMapsAllLocalPackagesToExplicitWorkspaceVersion(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+
+        $this->assertArrayHasKey('repositories', $manifest);
+        $this->assertCount(1, $manifest['repositories']);
+
+        $repository = $manifest['repositories'][0];
+
+        $this->assertSame('path', $repository['type']);
+        $this->assertSame('../packages/*', $repository['url']);
+        $this->assertArrayHasKey('options', $repository);
+        $this->assertArrayHasKey('versions', $repository['options']);
+        $this->assertSame('config', $repository['options']['reference']);
+        $this->assertArrayNotHasKey('symlink', $repository['options']);
+
+        $versions = $repository['options']['versions'];
+
+        $this->assertSame($this->allPackages(), array_keys($versions));
+
+        foreach ($versions as $package => $version) {
+            $this->assertSame('2.0.x-dev', $version, $package . ' should use the explicit workspace version.');
+        }
+    }
+
+    public function testWorkspaceRequiresProductionPackagesAndKeepsTestingInRequireDev(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+
+        $expectedRequire = array(
+            'php' => '^8.4',
+            'evolvephp/contracts' => '^2.0@dev',
+            'evolvephp/core' => '^2.0@dev',
+            'evolvephp/http' => '^2.0@dev',
+            'evolvephp/module' => '^2.0@dev',
+            'evolvephp/plugin' => '^2.0@dev',
+        );
+
+        $expectedRequireDev = array(
+            'evolvephp/testing' => '^2.0@dev',
+        );
+
+        $actualRequire = $manifest['require'];
+        $actualRequireDev = $manifest['require-dev'];
+
+        ksort($expectedRequire);
+        ksort($expectedRequireDev);
+        ksort($actualRequire);
+        ksort($actualRequireDev);
+
+        $this->assertSame($expectedRequire, $actualRequire);
+        $this->assertSame($expectedRequireDev, $actualRequireDev);
+        $this->assertArrayNotHasKey('evolvephp/testing', $actualRequire);
+
+        foreach ($this->productionPackages() as $package) {
+            $this->assertArrayNotHasKey($package, $actualRequireDev);
+        }
+    }
+
+    public function testWorkspaceComposerManifestAvoidsDeferredPolicyFieldsAndExternalDependencies(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+
+        foreach (array('version', 'minimum-stability', 'prefer-stable', 'autoload', 'autoload-dev', 'scripts') as $field) {
+            $this->assertArrayNotHasKey($field, $manifest, 'workspace/composer.json must not contain ' . $field . '.');
+        }
+
+        $this->assertTrue($manifest['config']['sort-packages']);
+        $this->assertFalse(isset($manifest['config']['platform']), 'workspace/composer.json must not emulate Composer platform configuration.');
+
+        foreach (array('require', 'require-dev') as $section) {
+            foreach (array_keys($manifest[$section]) as $dependency) {
+                $this->assertTrue(
+                    $dependency === 'php' || in_array($dependency, $this->allPackages(), true),
+                    $dependency . ' must not be added as an external workspace dependency.'
+                );
+            }
+        }
+    }
+
+    public function testWorkspaceReadmeDocumentsBoundarySolverOnlyVerificationAndLockfilePolicy(): void
+    {
+        $content = $this->readProjectFile('workspace/README.md');
+
+        $this->assertMatchesPattern('/dedicated EvolvePHP 2 Composer development root/i', $content);
+        $this->assertMatchesPattern('/legacy root Composer harness remains separate/i', $content);
+        $this->assertMatchesPattern('/not a publishable framework package/i', $content);
+        $this->assertMatchesPattern('/\.\.\/packages\/\*/i', $content);
+        $this->assertMatchesPattern('/2\.0\.x-dev/i', $content);
+        $this->assertMatchesPattern('/\^2\.0@dev/i', $content);
+        $this->assertMatchesPattern('/task-branch version ambiguity/i', $content);
+        $this->assertMatchesPattern('/minimum-stability/i', $content);
+        $this->assertMatchesPattern('/resolve all six packages as `?2\.0\.x-dev`?/i', $content);
+        $this->assertMatchesPattern('/production packages.*`require`/is', $content);
+        $this->assertMatchesPattern('/Testing.*`require-dev`/is', $content);
+        $this->assertMatchesPattern('/composer --working-dir=workspace validate --strict/i', $content);
+        $this->assertMatchesPattern('/--dry-run\s+\\\\?\s*--no-install\s+\\\\?\s*--no-interaction\s+\\\\?\s*--ignore-platform-req=php/is', $content);
+        $this->assertMatchesPattern('/dependency graph only/i', $content);
+        $this->assertMatchesPattern('/does not install packages/i', $content);
+        $this->assertMatchesPattern('/does not create the lockfile/i', $content);
+        $this->assertMatchesPattern('/does not prove PHP 8\.4 or 8\.5 runtime compatibility/i', $content);
+        $this->assertMatchesPattern('/must not be used for production installation or compatibility claims/i', $content);
+        $this->assertMatchesPattern('/workspace\/composer\.lock.*intended to be committed/is', $content);
+        $this->assertMatchesPattern('/intentionally absent in Phase 2\.2/i', $content);
+        $this->assertMatchesPattern('/generated under real PHP 8\.4 execution/i', $content);
+        $this->assertMatchesPattern('/through Composer, never manually/i', $content);
+    }
+
+    public function testGitignoreKeepsWorkspaceLockfileTrackableAndIgnoresWorkspaceVendor(): void
+    {
+        $content = $this->readProjectFile('.gitignore');
+
+        $generalLockfilePosition = strpos($content, 'composer.lock');
+        $workspaceLockfilePosition = strpos($content, '!workspace/composer.lock');
+
+        $this->assertNotFalse($generalLockfilePosition, '.gitignore should keep the general composer.lock rule.');
+        $this->assertNotFalse($workspaceLockfilePosition, '.gitignore should explicitly allow workspace/composer.lock.');
+        $this->assertGreaterThan($generalLockfilePosition, $workspaceLockfilePosition, 'workspace/composer.lock should be allowed after the general lockfile ignore rule.');
+        $this->assertMatchesPattern('/^\/workspace\/vendor\/$/m', $content);
+    }
+
+    public function testPackageReadmeReferencesTheDedicatedWorkspace(): void
+    {
+        $content = $this->readProjectFile('packages/README.md');
+
+        $this->assertMatchesPattern('/Phase 2\.2 now provides the dedicated Composer workspace/i', $content);
+        $this->assertMatchesPattern('/workspace\/README\.md/i', $content);
+        $this->assertMatchesPattern('/skeletons? only|no runtime implementation/i', $content);
+        $this->assertMatchesPattern('/not been installed or runtime-tested/i', $content);
+        $this->assertMatchesPattern('/Real PHP 8\.4 and PHP 8\.5 CI evidence is required before compatibility is claimed/i', $content);
+    }
+
+    public function testChangelogRecordsPhase22WorkspaceComposerConfiguration(): void
+    {
+        $content = $this->readProjectFile('CHANGELOG.md');
+
+        $this->assertMatchesPattern('/##\s+\[?Unreleased\]?/i', $content);
+        $this->assertMatchesPattern('/Phase 2\.2/i', $content);
+        $this->assertMatchesPattern('/dedicated EvolvePHP 2 Composer workspace/i', $content);
+        $this->assertMatchesPattern('/path-repository integration/i', $content);
+        $this->assertMatchesPattern('/2\.0\.x-dev package version mapping/i', $content);
+    }
+
+    private function allPackages()
+    {
+        return array(
+            'evolvephp/contracts',
+            'evolvephp/core',
+            'evolvephp/http',
+            'evolvephp/module',
+            'evolvephp/plugin',
+            'evolvephp/testing',
+        );
+    }
+
+    private function productionPackages()
+    {
+        return array(
+            'evolvephp/contracts',
+            'evolvephp/core',
+            'evolvephp/http',
+            'evolvephp/module',
+            'evolvephp/plugin',
+        );
+    }
+
+    private function projectPath($path)
+    {
+        return $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    private function readProjectFile($path)
+    {
+        $fullPath = $this->projectPath($path);
+        $this->assertFileExists($fullPath, $path . ' should exist before it is read.');
+
+        return file_get_contents($fullPath);
+    }
+
+    private function readJsonFile($path)
+    {
+        $content = $this->readProjectFile($path);
+        $json = json_decode($content, true);
+
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), $path . ' should contain valid JSON: ' . json_last_error_msg());
+        $this->assertIsArray($json, $path . ' should decode to a JSON object.');
+
+        return $json;
+    }
+
+    private function assertMatchesPattern($pattern, $content)
+    {
+        $this->assertSame(1, preg_match($pattern, $content), 'Failed asserting that content matches ' . $pattern);
+    }
+}

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,78 @@
+# EvolvePHP 2 Composer Workspace
+
+`workspace/` is the dedicated EvolvePHP 2 Composer development root for the modular monorepo.
+
+The legacy root Composer harness remains separate temporarily so the preserved EvolvePHP 1 repository and current architecture and documentation tests can continue to run from the repository root.
+
+This workspace is not a publishable framework package, a replacement for `evolvephp/framework`, an application skeleton, runtime framework code, a Composer plugin or a production deployment artifact.
+
+## Package Resolution
+
+Packages are resolved from one Composer path repository:
+
+```text
+../packages/*
+```
+
+Every Phase 2.1 package is mapped explicitly to `2.0.x-dev` inside the workspace path repository. The path repository remains the authoritative local package source. This avoids task-branch version ambiguity and lets local package manifests retain their normal `^2.0` dependency constraints without temporary package-level `version` fields.
+
+The workspace consumes those local packages through bounded `^2.0@dev` dependency constraints. The `@dev` stability flag permits the mapped development packages without adding project-wide `minimum-stability` or `prefer-stable` settings. Composer's solver output should still resolve all six packages as `2.0.x-dev`.
+
+Production packages are listed in `require`:
+
+- `evolvephp/contracts`
+- `evolvephp/core`
+- `evolvephp/http`
+- `evolvephp/module`
+- `evolvephp/plugin`
+
+Testing support is listed in `require-dev`:
+
+- `evolvephp/testing`
+
+Production packages remain independent of `evolvephp/testing`.
+
+## Local Commands
+
+Validate the workspace Composer schema:
+
+```bash
+composer --working-dir=workspace validate --strict
+```
+
+Under the current PHP 8.3 local environment, dependency-solver verification may be run as a graph-only dry run:
+
+```bash
+composer --working-dir=workspace update \
+  --dry-run \
+  --no-install \
+  --no-interaction \
+  --ignore-platform-req=php
+```
+
+This command verifies Composer's dependency graph only. It does not install packages, it does not create the lockfile, and it does not prove PHP 8.4 or 8.5 runtime compatibility.
+
+`--ignore-platform-req=php` must not be used for production installation or compatibility claims.
+
+## Lockfile
+
+`workspace/composer.lock` is intended to be committed for reproducible development and CI resolution.
+
+It is intentionally absent in Phase 2.2. The first workspace lockfile must be generated under real PHP 8.4 execution, reviewed, and committed by a later task. It must never be handwritten or generated with `config.platform.php`.
+
+Future changes to workspace dependencies must update the lockfile through Composer, never manually.
+
+## Deferred Work
+
+The following remain deferred:
+
+- PHPUnit workspace setup
+- Package test suites
+- Static analysis
+- Coding standards
+- Dependency-boundary tooling
+- GitHub Actions
+- PHP 8.4/8.5 runtime verification
+- Security and licence scanning
+- Release automation
+- Framework implementation

--- a/workspace/composer.json
+++ b/workspace/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "evolvephp/workspace",
+    "description": "Development workspace for the EvolvePHP 2 modular monorepo.",
+    "type": "project",
+    "license": "BSD-3-Clause",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../packages/*",
+            "options": {
+                "versions": {
+                    "evolvephp/contracts": "2.0.x-dev",
+                    "evolvephp/core": "2.0.x-dev",
+                    "evolvephp/http": "2.0.x-dev",
+                    "evolvephp/module": "2.0.x-dev",
+                    "evolvephp/plugin": "2.0.x-dev",
+                    "evolvephp/testing": "2.0.x-dev"
+                },
+                "reference": "config"
+            }
+        }
+    ],
+    "require": {
+        "php": "^8.4",
+        "evolvephp/contracts": "^2.0@dev",
+        "evolvephp/core": "^2.0@dev",
+        "evolvephp/http": "^2.0@dev",
+        "evolvephp/module": "^2.0@dev",
+        "evolvephp/plugin": "^2.0@dev"
+    },
+    "require-dev": {
+        "evolvephp/testing": "^2.0@dev"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
## Summary

* Add a dedicated Composer development workspace for EvolvePHP 2
* Preserve the legacy root Composer and PHPUnit harness
* Resolve the six Phase 2.1 packages through a local Composer path repository
* Map all local packages to `2.0.x-dev`
* Consume the local packages through bounded `^2.0@dev` constraints
* Keep the five production packages in `require`
* Keep `evolvephp/testing` in `require-dev`
* Configure stable path-package references using `reference: config`
* Document workspace purpose, dependency resolution and lockfile policy
* Make the future workspace lockfile trackable
* Ignore the workspace vendor directory
* Add automated Composer workspace architecture-policy tests
* Record Phase 2.2 in the changelog

## Workspace Design

The dedicated EvolvePHP 2 Composer workspace is located at:

```text
workspace/composer.json
```

The workspace is a development root for the EvolvePHP 2 modular monorepo.

It is not:

* A published framework package
* An application skeleton
* A replacement for the future `evolvephp/framework` metapackage
* A production deployment artifact
* Runtime framework implementation

The legacy root `composer.json` and `phpunit.xml.dist` remain unchanged and continue to support the existing EvolvePHP 1 repository and documentation-policy test harness.

## Local Package Repository

The workspace uses one Composer path repository:

```text
../packages/*
```

It discovers the six initial EvolvePHP 2 packages:

* `evolvephp/contracts`
* `evolvephp/core`
* `evolvephp/http`
* `evolvephp/module`
* `evolvephp/plugin`
* `evolvephp/testing`

The path repository explicitly exposes every local package as:

```text
2.0.x-dev
```

This prevents the current Git branch name from affecting Composer package-version detection.

The path repository uses:

```json
"reference": "config"
```

No symlink or mirror mode is forced.

## Workspace Dependency Constraints

The workspace consumes the five production packages through bounded development constraints:

```text
^2.0@dev
```

Production requirements:

* `evolvephp/contracts`
* `evolvephp/core`
* `evolvephp/http`
* `evolvephp/module`
* `evolvephp/plugin`

Development requirement:

* `evolvephp/testing`

The `@dev` stability flag permits the locally mapped `2.0.x-dev` packages without adding project-wide `minimum-stability`.

No package manifest was modified to add a `version` field.

## Dependency Direction

The existing package dependency direction remains:

```text
contracts
    ^
    |
core
    ^
    |
http

contracts <- module
contracts <- plugin

testing -> contracts, core, http, module, plugin
```

Production packages do not depend on `evolvephp/testing`.

## Composer Validation

Strict workspace validation passed:

```bash
composer --working-dir=workspace validate --strict
```

Result:

```text
./composer.json is valid
```

All six package manifests also passed strict Composer validation.

The legacy root Composer manifest remains valid with its existing warning about the root `version` field.

That warning is pre-existing and was not changed in this task.

## Dependency-Solver Verification

The local dependency graph was verified using:

```bash
composer --working-dir=workspace update \
  --dry-run \
  --no-install \
  --no-interaction \
  --no-audit \
  --ignore-platform-req=php
```

Composer resolved:

* `evolvephp/contracts 2.0.x-dev`
* `evolvephp/core 2.0.x-dev`
* `evolvephp/http 2.0.x-dev`
* `evolvephp/module 2.0.x-dev`
* `evolvephp/plugin 2.0.x-dev`
* `evolvephp/testing 2.0.x-dev`

Solver summary:

```text
Lock file operations: 6 installs, 0 updates, 0 removals
```

This was a dry-run dependency-resolution check only.

No packages were installed.

## Test Evidence

* Workspace Composer policy suite: `OK (8 tests, 93 assertions)`
* Complete architecture suite: `OK (16 tests, 347 assertions)`
* Documentation suite: `OK (76 tests, 754 assertions)`
* Complete available suite: `OK (92 tests, 1101 assertions)`

`git diff --check` also passed.

## Environment

* PHP 8.3.7
* PHPUnit 10.5.0
* Composer 2.7.6

PHP 8.3 was used for:

* Architecture-policy tests
* Documentation-policy tests
* Composer manifest validation
* Solver-only dependency resolution

The solver command explicitly ignored only the PHP platform requirement.

This does not establish EvolvePHP 2 runtime compatibility with PHP 8.4 or PHP 8.5.

Real PHP 8.4 and PHP 8.5 execution remains required before compatibility is claimed.

## Lockfile Policy

`workspace/composer.lock` is intended to be committed later for reproducible development and CI dependency resolution.

It is intentionally absent from this change.

The first workspace lockfile must:

* Be generated using a real supported PHP 8.4 runtime
* Be generated through Composer
* Be reviewed before commit
* Never be handwritten
* Never be generated through `config.platform.php` emulation

The repository now allows `workspace/composer.lock` to be tracked while continuing to ignore unrelated Composer lockfiles under the existing legacy policy.

The workspace vendor directory is ignored:

```text
/workspace/vendor/
```

Confirmed absent after validation:

```text
workspace/composer.lock
workspace/vendor/
```

## Files Changed

Modified:

* `.gitignore`
* `CHANGELOG.md`
* `packages/README.md`

Created:

* `workspace/composer.json`
* `workspace/README.md`
* `tests/Architecture/EvolvePhp2WorkspaceComposerTest.php`

Final scope:

```text
6 files changed, 340 insertions, 5 deletions
```

## Scope Confirmation

This change does not include:

* Root Composer conversion
* Root PHPUnit changes
* Package manifest changes
* Package version fields
* Runtime framework implementation
* Public contracts or interfaces
* Kernel or container implementation
* HTTP implementation
* Module lifecycle implementation
* Plugin lifecycle implementation
* Testing utilities
* Workspace PHPUnit dependency
* Package-level test suites
* Static analysis
* Coding standards
* GitHub Actions
* Security or licence scanning
* Release automation
* Composer installation
* Workspace lockfile
* Workspace vendor directory
* RFC changes
* Legacy EvolvePHP 1 source changes
* Phase 2.3 work
