### PR TITLE
test: establish PHPUnit workspace foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation and governance
 
+- Added Phase 2.3 PHPUnit 13 workspace foundation, six package test suites, and the initial workspace lockfile generated under PHP 8.4.
 - Added Phase 2.2 dedicated EvolvePHP 2 Composer workspace with local path-repository integration and explicit 2.0.x-dev package version mapping.
 - Added Phase 2.1 initial EvolvePHP 2 package skeleton boundaries for the accepted alpha package map.
 - Added Cross-RFC terminology harmonization, Bridge dependency-direction clarification, execution-scoped tenant-context clarification, and telemetry finalization and scope-closure ordering clarification for accepted EvolvePHP 2 RFCs 0001-0006.

--- a/packages/README.md
+++ b/packages/README.md
@@ -50,4 +50,12 @@ The current root Composer manifest remains the legacy EvolvePHP 1 harness tempor
 
 Phase 2.2 now provides the dedicated Composer workspace; this is the EvolvePHP 2 workspace Composer configuration for development. See `workspace/README.md` for package-resolution, lockfile and local solver-verification policy.
 
+Phase 2.3 adds `tests/Unit/` to each initial package. Package tests are orchestrated from `workspace/phpunit.xml.dist`, not from package-level PHPUnit installations.
+
+The initial package smoke tests verify package identity and source namespace declarations only. Runtime behaviour tests will be added alongside actual implementation.
+
+Package Composer manifests remain free from workspace PHPUnit dependencies. PHPUnit belongs to `workspace/composer.json` as a development dependency.
+
+Before Phase 2.3, the packages had not been installed or runtime-tested. Phase 2.3 verifies the package test skeletons through the dedicated workspace suite without adding runtime framework behaviour.
+
 Real PHP 8.4 and PHP 8.5 CI evidence is required before compatibility is claimed. Composer manifest validation under another local PHP version does not establish EvolvePHP 2 runtime compatibility.

--- a/packages/contracts/tests/Unit/PackageManifestTest.php
+++ b/packages/contracts/tests/Unit/PackageManifestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Contracts\Tests\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class PackageManifestTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_package_identity_and_source_namespace_are_declared(): void
+    {
+        $manifestPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'composer.json';
+        $contents = file_get_contents($manifestPath);
+
+        self::assertNotFalse($contents);
+
+        $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('evolvephp/contracts', $manifest['name']);
+        self::assertSame(
+            ['Evolve\\Contracts\\' => 'src/'],
+            $manifest['autoload']['psr-4'],
+        );
+    }
+}

--- a/packages/core/tests/Unit/PackageManifestTest.php
+++ b/packages/core/tests/Unit/PackageManifestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class PackageManifestTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_package_identity_and_source_namespace_are_declared(): void
+    {
+        $manifestPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'composer.json';
+        $contents = file_get_contents($manifestPath);
+
+        self::assertNotFalse($contents);
+
+        $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('evolvephp/core', $manifest['name']);
+        self::assertSame(
+            ['Evolve\\Core\\' => 'src/'],
+            $manifest['autoload']['psr-4'],
+        );
+    }
+}

--- a/packages/http/tests/Unit/PackageManifestTest.php
+++ b/packages/http/tests/Unit/PackageManifestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Http\Tests\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class PackageManifestTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_package_identity_and_source_namespace_are_declared(): void
+    {
+        $manifestPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'composer.json';
+        $contents = file_get_contents($manifestPath);
+
+        self::assertNotFalse($contents);
+
+        $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('evolvephp/http', $manifest['name']);
+        self::assertSame(
+            ['Evolve\\Http\\' => 'src/'],
+            $manifest['autoload']['psr-4'],
+        );
+    }
+}

--- a/packages/module/tests/Unit/PackageManifestTest.php
+++ b/packages/module/tests/Unit/PackageManifestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Module\Tests\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class PackageManifestTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_package_identity_and_source_namespace_are_declared(): void
+    {
+        $manifestPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'composer.json';
+        $contents = file_get_contents($manifestPath);
+
+        self::assertNotFalse($contents);
+
+        $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('evolvephp/module', $manifest['name']);
+        self::assertSame(
+            ['Evolve\\Module\\' => 'src/'],
+            $manifest['autoload']['psr-4'],
+        );
+    }
+}

--- a/packages/plugin/tests/Unit/PackageManifestTest.php
+++ b/packages/plugin/tests/Unit/PackageManifestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Plugin\Tests\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class PackageManifestTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_package_identity_and_source_namespace_are_declared(): void
+    {
+        $manifestPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'composer.json';
+        $contents = file_get_contents($manifestPath);
+
+        self::assertNotFalse($contents);
+
+        $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('evolvephp/plugin', $manifest['name']);
+        self::assertSame(
+            ['Evolve\\Plugin\\' => 'src/'],
+            $manifest['autoload']['psr-4'],
+        );
+    }
+}

--- a/packages/testing/tests/Unit/PackageManifestTest.php
+++ b/packages/testing/tests/Unit/PackageManifestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Testing\Tests\Unit;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class PackageManifestTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_package_identity_and_source_namespace_are_declared(): void
+    {
+        $manifestPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'composer.json';
+        $contents = file_get_contents($manifestPath);
+
+        self::assertNotFalse($contents);
+
+        $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('evolvephp/testing', $manifest['name']);
+        self::assertSame(
+            ['Evolve\\Testing\\' => 'src/'],
+            $manifest['autoload']['psr-4'],
+        );
+    }
+}

--- a/tests/Architecture/EvolvePhp2PhpUnitFoundationTest.php
+++ b/tests/Architecture/EvolvePhp2PhpUnitFoundationTest.php
@@ -1,0 +1,279 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class EvolvePhp2PhpUnitFoundationTest extends TestCase
+{
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testWorkspaceRequiresPhpUnitOnlyAsADevelopmentDependency(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+
+        $this->assertArrayHasKey('require-dev', $manifest);
+        $this->assertArrayHasKey('evolvephp/testing', $manifest['require-dev']);
+        $this->assertSame('^2.0@dev', $manifest['require-dev']['evolvephp/testing']);
+        $this->assertArrayHasKey('phpunit/phpunit', $manifest['require-dev']);
+        $this->assertSame('^13.2', $manifest['require-dev']['phpunit/phpunit']);
+        $this->assertArrayNotHasKey('phpunit/phpunit', $manifest['require']);
+    }
+
+    public function testWorkspaceComposerScriptsRunTheApprovedPhpUnitSuites(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+        $expectedScripts = $this->workspaceScripts();
+
+        $this->assertArrayHasKey('scripts', $manifest);
+
+        $actualScripts = $manifest['scripts'];
+        ksort($expectedScripts);
+        ksort($actualScripts);
+
+        $this->assertSame($expectedScripts, $actualScripts);
+
+        foreach ($actualScripts as $script) {
+            $this->assertStringContainsString('--configuration phpunit.xml.dist', $script);
+        }
+    }
+
+    public function testWorkspacePhpUnitConfigurationDefinesSixPackageSuites(): void
+    {
+        $path = $this->projectPath('workspace/phpunit.xml.dist');
+
+        $this->assertFileExists($path);
+
+        $document = new DOMDocument();
+        $this->assertTrue($document->load($path), 'workspace/phpunit.xml.dist should be well formed XML.');
+
+        $root = $document->documentElement;
+
+        $this->assertSame('phpunit', $root->tagName);
+        $this->assertSame('vendor/autoload.php', $root->getAttribute('bootstrap'));
+        $this->assertSame('false', $root->getAttribute('cacheResult'));
+
+        $xpath = new DOMXPath($document);
+        $suiteNodes = $xpath->query('/phpunit/testsuites/testsuite');
+
+        $this->assertNotFalse($suiteNodes);
+        $this->assertSame(array_keys($this->packageSuites()), $this->nodeAttributeValues($suiteNodes, 'name'));
+
+        foreach ($suiteNodes as $suiteNode) {
+            $suiteName = $suiteNode->getAttribute('name');
+            $directories = $xpath->query('directory', $suiteNode);
+
+            $this->assertNotFalse($directories);
+            $this->assertSame(1, $directories->length, $suiteName . ' should declare one test directory.');
+            $this->assertSame($this->packageSuites()[$suiteName]['tests'], trim($directories->item(0)->textContent));
+            $this->assertSame('Test.php', $directories->item(0)->getAttribute('suffix'));
+        }
+    }
+
+    public function testEachPackageHasAManifestSmokeTest(): void
+    {
+        foreach ($this->packageSuites() as $suite) {
+            $this->assertFileExists($this->projectPath($suite['smokeTest']));
+            $this->assertNotSame(
+                array(),
+                $this->phpTestFilesUnder($this->projectPath(dirname($suite['smokeTest'], 2))),
+                $suite['tests'] . ' should contain at least one test file.'
+            );
+        }
+    }
+
+    public function testWorkspaceLockfileRecordsLocalPackagesAndPhpUnit13(): void
+    {
+        $lock = $this->readJsonFile('workspace/composer.lock');
+
+        $this->assertArrayHasKey('content-hash', $lock);
+        $this->assertNotSame('', $lock['content-hash']);
+        $this->assertSame('^8.4', $lock['platform']['php']);
+
+        $packages = $this->lockedPackages($lock);
+
+        foreach ($this->expectedLockedPackages() as $package) {
+            $this->assertArrayHasKey($package, $packages, $package . ' should be locked.');
+        }
+
+        $this->assertSame(13, (int) strtok($packages['phpunit/phpunit'], '.'));
+    }
+
+    public function testWorkspaceReadmeDocumentsPhpUnitFoundationPolicy(): void
+    {
+        $content = $this->readProjectFile('workspace/README.md');
+
+        $this->assertMatchesPattern('/PHPUnit 13/i', $content);
+        $this->assertMatchesPattern('/PHP 8\.4/i', $content);
+        $this->assertMatchesPattern('/workspace\/phpunit\.xml\.dist/i', $content);
+        $this->assertMatchesPattern('/composer --working-dir=workspace test/i', $content);
+        $this->assertMatchesPattern('/test:contracts/i', $content);
+        $this->assertMatchesPattern('/test:core/i', $content);
+        $this->assertMatchesPattern('/test:http/i', $content);
+        $this->assertMatchesPattern('/test:module/i', $content);
+        $this->assertMatchesPattern('/test:plugin/i', $content);
+        $this->assertMatchesPattern('/test:testing/i', $content);
+        $this->assertMatchesPattern('/workspace\/composer\.lock/i', $content);
+        $this->assertMatchesPattern('/platform emulation/i', $content);
+        $this->assertMatchesPattern('/PHP 8\.5 CI.*Phase 2\.6/i', $content);
+        $this->assertMatchesPattern('/Static analysis.*Phase 2\.4/i', $content);
+        $this->assertMatchesPattern('/legacy root suite/i', $content);
+        $this->assertMatchesPattern('/EvolvePHP 2 workspace suite/i', $content);
+    }
+
+    public function testPackagesReadmeDocumentsPackageTestDirectories(): void
+    {
+        $content = $this->readProjectFile('packages/README.md');
+
+        $this->assertMatchesPattern('/tests\/Unit\//i', $content);
+        $this->assertMatchesPattern('/workspace\/phpunit\.xml\.dist/i', $content);
+        $this->assertMatchesPattern('/package identity and source namespace/i', $content);
+        $this->assertMatchesPattern('/Runtime behaviour tests will be added/i', $content);
+        $this->assertMatchesPattern('/Composer manifests remain free from workspace PHPUnit dependencies/i', $content);
+    }
+
+    public function testChangelogRecordsPhase23PhpUnitFoundation(): void
+    {
+        $content = $this->readProjectFile('CHANGELOG.md');
+
+        $this->assertMatchesPattern('/##\s+\[?Unreleased\]?/i', $content);
+        $this->assertMatchesPattern('/Phase 2\.3/i', $content);
+        $this->assertMatchesPattern('/PHPUnit 13/i', $content);
+        $this->assertMatchesPattern('/six package test suites/i', $content);
+        $this->assertMatchesPattern('/PHP 8\.4/i', $content);
+    }
+
+    private function packageSuites()
+    {
+        return array(
+            'contracts' => array(
+                'tests' => '../packages/contracts/tests',
+                'smokeTest' => 'packages/contracts/tests/Unit/PackageManifestTest.php',
+            ),
+            'core' => array(
+                'tests' => '../packages/core/tests',
+                'smokeTest' => 'packages/core/tests/Unit/PackageManifestTest.php',
+            ),
+            'http' => array(
+                'tests' => '../packages/http/tests',
+                'smokeTest' => 'packages/http/tests/Unit/PackageManifestTest.php',
+            ),
+            'module' => array(
+                'tests' => '../packages/module/tests',
+                'smokeTest' => 'packages/module/tests/Unit/PackageManifestTest.php',
+            ),
+            'plugin' => array(
+                'tests' => '../packages/plugin/tests',
+                'smokeTest' => 'packages/plugin/tests/Unit/PackageManifestTest.php',
+            ),
+            'testing' => array(
+                'tests' => '../packages/testing/tests',
+                'smokeTest' => 'packages/testing/tests/Unit/PackageManifestTest.php',
+            ),
+        );
+    }
+
+    private function workspaceScripts()
+    {
+        return array(
+            'test' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist',
+            'test:contracts' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite contracts',
+            'test:core' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite core',
+            'test:http' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite http',
+            'test:module' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite module',
+            'test:plugin' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite plugin',
+            'test:testing' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite testing',
+        );
+    }
+
+    private function expectedLockedPackages()
+    {
+        return array(
+            'evolvephp/contracts',
+            'evolvephp/core',
+            'evolvephp/http',
+            'evolvephp/module',
+            'evolvephp/plugin',
+            'evolvephp/testing',
+            'phpunit/phpunit',
+        );
+    }
+
+    private function lockedPackages(array $lock)
+    {
+        $packages = array();
+
+        foreach (array('packages', 'packages-dev') as $section) {
+            foreach ($lock[$section] as $package) {
+                $packages[$package['name']] = $package['version'];
+            }
+        }
+
+        return $packages;
+    }
+
+    private function nodeAttributeValues(DOMNodeList $nodes, $attribute)
+    {
+        $values = array();
+
+        foreach ($nodes as $node) {
+            $values[] = $node->getAttribute($attribute);
+        }
+
+        return $values;
+    }
+
+    private function phpTestFilesUnder($directory)
+    {
+        if (!is_dir($directory)) {
+            return array();
+        }
+
+        $files = array();
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && substr($file->getFilename(), -8) === 'Test.php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function projectPath($path)
+    {
+        return $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    private function readProjectFile($path)
+    {
+        $fullPath = $this->projectPath($path);
+        $this->assertFileExists($fullPath, $path . ' should exist before it is read.');
+
+        return file_get_contents($fullPath);
+    }
+
+    private function readJsonFile($path)
+    {
+        $content = $this->readProjectFile($path);
+        $json = json_decode($content, true);
+
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), $path . ' should contain valid JSON: ' . json_last_error_msg());
+        $this->assertIsArray($json, $path . ' should decode to a JSON object.');
+
+        return $json;
+    }
+
+    private function assertMatchesPattern($pattern, $content)
+    {
+        $this->assertSame(1, preg_match($pattern, $content), 'Failed asserting that content matches ' . $pattern);
+    }
+}

--- a/tests/Architecture/EvolvePhp2WorkspaceComposerTest.php
+++ b/tests/Architecture/EvolvePhp2WorkspaceComposerTest.php
@@ -45,7 +45,7 @@ final class EvolvePhp2WorkspaceComposerTest extends TestCase
         }
     }
 
-    public function testWorkspaceRequiresProductionPackagesAndKeepsTestingInRequireDev(): void
+    public function testWorkspaceRequiresProductionPackagesAndApprovedDevelopmentTools(): void
     {
         $manifest = $this->readJsonFile('workspace/composer.json');
 
@@ -60,6 +60,7 @@ final class EvolvePhp2WorkspaceComposerTest extends TestCase
 
         $expectedRequireDev = array(
             'evolvephp/testing' => '^2.0@dev',
+            'phpunit/phpunit' => '^13.2',
         );
 
         $actualRequire = $manifest['require'];
@@ -73,31 +74,53 @@ final class EvolvePhp2WorkspaceComposerTest extends TestCase
         $this->assertSame($expectedRequire, $actualRequire);
         $this->assertSame($expectedRequireDev, $actualRequireDev);
         $this->assertArrayNotHasKey('evolvephp/testing', $actualRequire);
+        $this->assertArrayNotHasKey('phpunit/phpunit', $actualRequire);
 
         foreach ($this->productionPackages() as $package) {
             $this->assertArrayNotHasKey($package, $actualRequireDev);
         }
     }
 
-    public function testWorkspaceComposerManifestAvoidsDeferredPolicyFieldsAndExternalDependencies(): void
+    public function testWorkspaceComposerManifestAvoidsDeferredPolicyFieldsAndUnapprovedDependencies(): void
     {
         $manifest = $this->readJsonFile('workspace/composer.json');
 
-        foreach (array('version', 'minimum-stability', 'prefer-stable', 'autoload', 'autoload-dev', 'scripts') as $field) {
+        foreach (array('version', 'minimum-stability', 'prefer-stable', 'autoload', 'autoload-dev') as $field) {
             $this->assertArrayNotHasKey($field, $manifest, 'workspace/composer.json must not contain ' . $field . '.');
         }
 
         $this->assertTrue($manifest['config']['sort-packages']);
         $this->assertFalse(isset($manifest['config']['platform']), 'workspace/composer.json must not emulate Composer platform configuration.');
 
-        foreach (array('require', 'require-dev') as $section) {
-            foreach (array_keys($manifest[$section]) as $dependency) {
-                $this->assertTrue(
-                    $dependency === 'php' || in_array($dependency, $this->allPackages(), true),
-                    $dependency . ' must not be added as an external workspace dependency.'
-                );
-            }
-        }
+        $allowedRequire = array(
+            'php',
+            'evolvephp/contracts',
+            'evolvephp/core',
+            'evolvephp/http',
+            'evolvephp/module',
+            'evolvephp/plugin',
+        );
+        $allowedRequireDev = array('evolvephp/testing', 'phpunit/phpunit');
+
+        $this->assertSame($allowedRequire, array_keys($manifest['require']));
+        $this->assertSame($allowedRequireDev, array_keys($manifest['require-dev']));
+    }
+
+    public function testWorkspaceComposerManifestDeclaresOnlyApprovedPhpUnitScripts(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+        $expectedScripts = array(
+            'test' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist',
+            'test:contracts' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite contracts',
+            'test:core' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite core',
+            'test:http' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite http',
+            'test:module' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite module',
+            'test:plugin' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite plugin',
+            'test:testing' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite testing',
+        );
+
+        $this->assertArrayHasKey('scripts', $manifest);
+        $this->assertSame($expectedScripts, $manifest['scripts']);
     }
 
     public function testWorkspaceReadmeDocumentsBoundarySolverOnlyVerificationAndLockfilePolicy(): void
@@ -115,16 +138,14 @@ final class EvolvePhp2WorkspaceComposerTest extends TestCase
         $this->assertMatchesPattern('/resolve all six packages as `?2\.0\.x-dev`?/i', $content);
         $this->assertMatchesPattern('/production packages.*`require`/is', $content);
         $this->assertMatchesPattern('/Testing.*`require-dev`/is', $content);
+        $this->assertMatchesPattern('/PHPUnit 13.*workspace/is', $content);
         $this->assertMatchesPattern('/composer --working-dir=workspace validate --strict/i', $content);
-        $this->assertMatchesPattern('/--dry-run\s+\\\\?\s*--no-install\s+\\\\?\s*--no-interaction\s+\\\\?\s*--ignore-platform-req=php/is', $content);
-        $this->assertMatchesPattern('/dependency graph only/i', $content);
-        $this->assertMatchesPattern('/does not install packages/i', $content);
-        $this->assertMatchesPattern('/does not create the lockfile/i', $content);
-        $this->assertMatchesPattern('/does not prove PHP 8\.4 or 8\.5 runtime compatibility/i', $content);
-        $this->assertMatchesPattern('/must not be used for production installation or compatibility claims/i', $content);
-        $this->assertMatchesPattern('/workspace\/composer\.lock.*intended to be committed/is', $content);
-        $this->assertMatchesPattern('/intentionally absent in Phase 2\.2/i', $content);
-        $this->assertMatchesPattern('/generated under real PHP 8\.4 execution/i', $content);
+        $this->assertMatchesPattern('/composer --working-dir=workspace test/i', $content);
+        $this->assertMatchesPattern('/workspace\/phpunit\.xml\.dist/i', $content);
+        $this->assertMatchesPattern('/workspace\/vendor\/autoload\.php/i', $content);
+        $this->assertMatchesPattern('/workspace\/composer\.lock.*committed/is', $content);
+        $this->assertMatchesPattern('/Phase 2\.3.*first workspace lockfile.*real PHP 8\.4/is', $content);
+        $this->assertMatchesPattern('/Platform emulation must not be used/i', $content);
         $this->assertMatchesPattern('/through Composer, never manually/i', $content);
     }
 
@@ -148,7 +169,9 @@ final class EvolvePhp2WorkspaceComposerTest extends TestCase
         $this->assertMatchesPattern('/Phase 2\.2 now provides the dedicated Composer workspace/i', $content);
         $this->assertMatchesPattern('/workspace\/README\.md/i', $content);
         $this->assertMatchesPattern('/skeletons? only|no runtime implementation/i', $content);
-        $this->assertMatchesPattern('/not been installed or runtime-tested/i', $content);
+        $this->assertMatchesPattern('/tests\/Unit\//i', $content);
+        $this->assertMatchesPattern('/workspace\/phpunit\.xml\.dist/i', $content);
+        $this->assertMatchesPattern('/Before Phase 2\.3.*not been installed or runtime-tested/is', $content);
         $this->assertMatchesPattern('/Real PHP 8\.4 and PHP 8\.5 CI evidence is required before compatibility is claimed/i', $content);
     }
 

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -29,8 +29,11 @@ Production packages are listed in `require`:
 Testing support is listed in `require-dev`:
 
 - `evolvephp/testing`
+- `phpunit/phpunit`
 
 Production packages remain independent of `evolvephp/testing`.
+
+PHPUnit 13 is owned by the EvolvePHP 2 workspace. It must not be added to the legacy root Composer manifest, any package manifest or production requirements.
 
 ## Local Commands
 
@@ -40,25 +43,58 @@ Validate the workspace Composer schema:
 composer --working-dir=workspace validate --strict
 ```
 
-Under the current PHP 8.3 local environment, dependency-solver verification may be run as a graph-only dry run:
+Install or update workspace dependencies only through real Composer execution on PHP 8.4:
 
 ```bash
 composer --working-dir=workspace update \
-  --dry-run \
-  --no-install \
   --no-interaction \
-  --ignore-platform-req=php
+  --no-progress \
+  --no-audit
 ```
 
-This command verifies Composer's dependency graph only. It does not install packages, it does not create the lockfile, and it does not prove PHP 8.4 or 8.5 runtime compatibility.
+Run the complete EvolvePHP 2 workspace PHPUnit suite:
 
-`--ignore-platform-req=php` must not be used for production installation or compatibility claims.
+```bash
+composer --working-dir=workspace test
+```
+
+Run individual package suites:
+
+```bash
+composer --working-dir=workspace test:contracts
+composer --working-dir=workspace test:core
+composer --working-dir=workspace test:http
+composer --working-dir=workspace test:module
+composer --working-dir=workspace test:plugin
+composer --working-dir=workspace test:testing
+```
+
+The workspace PHPUnit configuration lives at:
+
+```text
+workspace/phpunit.xml.dist
+```
+
+It bootstraps through `workspace/vendor/autoload.php` and defines one named suite for each initial package:
+
+| Suite | Test directory |
+| --- | --- |
+| `contracts` | `packages/contracts/tests` |
+| `core` | `packages/core/tests` |
+| `http` | `packages/http/tests` |
+| `module` | `packages/module/tests` |
+| `plugin` | `packages/plugin/tests` |
+| `testing` | `packages/testing/tests` |
+
+The legacy root suite and the EvolvePHP 2 workspace suite are separate harnesses. The legacy root suite continues to preserve and validate repository policy while the workspace suite runs package tests under the EvolvePHP 2 PHP baseline.
+
+Platform emulation must not be used for runtime compatibility claims. Do not use `config.platform.php`, `--ignore-platform-req=php` or `--ignore-platform-reqs` to generate the workspace lockfile or claim PHP compatibility.
 
 ## Lockfile
 
-`workspace/composer.lock` is intended to be committed for reproducible development and CI resolution.
+`workspace/composer.lock` is committed for reproducible development and CI resolution.
 
-It is intentionally absent in Phase 2.2. The first workspace lockfile must be generated under real PHP 8.4 execution, reviewed, and committed by a later task. It must never be handwritten or generated with `config.platform.php`.
+It was intentionally absent in Phase 2.2. Phase 2.3 creates the first workspace lockfile under real PHP 8.4 execution. It must never be handwritten or generated with `config.platform.php`.
 
 Future changes to workspace dependencies must update the lockfile through Composer, never manually.
 
@@ -66,13 +102,11 @@ Future changes to workspace dependencies must update the lockfile through Compos
 
 The following remain deferred:
 
-- PHPUnit workspace setup
-- Package test suites
-- Static analysis
-- Coding standards
+- Static analysis to Phase 2.4
+- Coding standards to Phase 2.4
 - Dependency-boundary tooling
 - GitHub Actions
-- PHP 8.4/8.5 runtime verification
+- PHP 8.5 CI verification to Phase 2.6
 - Security and licence scanning
 - Release automation
 - Framework implementation

--- a/workspace/composer.json
+++ b/workspace/composer.json
@@ -29,7 +29,17 @@
         "evolvephp/plugin": "^2.0@dev"
     },
     "require-dev": {
-        "evolvephp/testing": "^2.0@dev"
+        "evolvephp/testing": "^2.0@dev",
+        "phpunit/phpunit": "^13.2"
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit --configuration phpunit.xml.dist",
+        "test:contracts": "@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite contracts",
+        "test:core": "@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite core",
+        "test:http": "@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite http",
+        "test:module": "@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite module",
+        "test:plugin": "@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite plugin",
+        "test:testing": "@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite testing"
     },
     "config": {
         "sort-packages": true

--- a/workspace/composer.lock
+++ b/workspace/composer.lock
@@ -1,0 +1,2108 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "f0848682626c178f0450112dad7cbdbd",
+    "packages": [
+        {
+            "name": "evolvephp/contracts",
+            "version": "2.0.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "../packages/contracts",
+                "reference": "4588e71cec1200f3faab2a577b6ecc48269640f5"
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evolve\\Contracts\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Foundational public contracts for EvolvePHP 2.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "evolvephp/core",
+            "version": "2.0.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "../packages/core",
+                "reference": "5fd6fe298fe5ddc16b2c701cd7b8213c6bec51b1"
+            },
+            "require": {
+                "evolvephp/contracts": "^2.0",
+                "php": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evolve\\Core\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Application kernel and runtime-neutral orchestration for EvolvePHP 2.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "evolvephp/http",
+            "version": "2.0.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "../packages/http",
+                "reference": "ca02cbb87575ab50425c93ef64179a112a2b62d9"
+            },
+            "require": {
+                "evolvephp/contracts": "^2.0",
+                "evolvephp/core": "^2.0",
+                "php": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evolve\\Http\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "HTTP lifecycle, routing and middleware foundations for EvolvePHP 2.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "evolvephp/module",
+            "version": "2.0.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "../packages/module",
+                "reference": "49dbb11bbaf7b3055f96e1088bb7b6426456fc08"
+            },
+            "require": {
+                "evolvephp/contracts": "^2.0",
+                "php": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evolve\\Module\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Application module SDK and lifecycle support for EvolvePHP 2.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "evolvephp/plugin",
+            "version": "2.0.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "../packages/plugin",
+                "reference": "37635d4cc25735038fc80f144af7e8ebb9ae8ad2"
+            },
+            "require": {
+                "evolvephp/contracts": "^2.0",
+                "php": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evolve\\Plugin\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Framework plugin SDK and lifecycle support for EvolvePHP 2.",
+            "transport-options": {
+                "relative": true
+            }
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "evolvephp/testing",
+            "version": "2.0.x-dev",
+            "dist": {
+                "type": "path",
+                "url": "../packages/testing",
+                "reference": "b80336f2ede6a0f9b6a932430c461b9b0d97fd0e"
+            },
+            "require": {
+                "evolvephp/contracts": "^2.0",
+                "evolvephp/core": "^2.0",
+                "evolvephp/http": "^2.0",
+                "evolvephp/module": "^2.0",
+                "evolvephp/plugin": "^2.0",
+                "php": "^8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evolve\\Testing\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Testing utilities for EvolvePHP 2 packages and applications.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "14.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/048a5c12bdb4580f4767ce2761793a16b170fbe4",
+                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4",
+                "phpunit/php-text-template": "^6.0",
+                "sebastian/complexity": "^6.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/git-state": "^1.0",
+                "sebastian/lines-of-code": "^5.0.1",
+                "sebastian/version": "^7.0",
+                "theseer/tokenizer": "^2.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.2"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "14.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-30T17:01:07+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:33:26+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^13.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:34:47+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:36:37+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:37:53+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "13.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5d2afe181339a56348ef9a80fa7eb806b7eae508",
+                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.4.1",
+                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-file-iterator": "^7.0.0",
+                "phpunit/php-invoker": "^7.0.0",
+                "phpunit/php-text-template": "^6.0.0",
+                "phpunit/php-timer": "^9.0.0",
+                "sebastian/cli-parser": "^5.0.0",
+                "sebastian/comparator": "^8.3.0",
+                "sebastian/diff": "^9.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/exporter": "^8.1.1",
+                "sebastian/file-filter": "^1.0",
+                "sebastian/git-state": "^1.0",
+                "sebastian/global-state": "^9.0.1",
+                "sebastian/object-enumerator": "^8.0.0",
+                "sebastian/recursion-context": "^8.0.0",
+                "sebastian/type": "^7.0.1",
+                "sebastian/version": "^7.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "13.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-28T14:00:09+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/eeb759ad3146b7096fb59c3195d39e071cd409e3",
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-01T04:27:14+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "8.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c025fc7604afab3f195fab7cdaf72327331af241",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.4",
+                "sebastian/diff": "^9.0",
+                "sebastian/exporter": "^8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T03:06:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c5651c795c98093480df79350cb050813fc7a2f3",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:41:32+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2",
+                "symfony/process": "^7.4.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/9.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T03:04:51+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "9.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.1.11"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:41:38+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.4",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-13T11:35:11+00:00"
+        },
+        {
+            "name": "sebastian/file-filter",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/file-filter.git",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for filtering files",
+            "homepage": "https://github.com/sebastianbergmann/file-filter",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/file-filter/issues",
+                "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/file-filter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T07:20:04+00:00"
+        },
+        {
+            "name": "sebastian/git-state",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/git-state.git",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for describing the state of a Git checkout",
+            "homepage": "https://github.com/sebastianbergmann/git-state",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/git-state/issues",
+                "security": "https://github.com/sebastianbergmann/git-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/git-state/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/git-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T12:54:28+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^13.1.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T15:11:33+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-09T08:42:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:46:36+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:47:13+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0",
+                "reference": "32dba72f2b4642d6a93db22d6c0a9280ff2e3ca0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/8.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-03T05:58:12+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.1.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T06:49:11+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:52:52+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-08T11:19:18+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "evolvephp/contracts": 20,
+        "evolvephp/core": 20,
+        "evolvephp/http": 20,
+        "evolvephp/module": 20,
+        "evolvephp/plugin": 20,
+        "evolvephp/testing": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.4"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/workspace/phpunit.xml.dist
+++ b/workspace/phpunit.xml.dist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    cacheResult="false"
+    beStrictAboutOutputDuringTests="true"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnDeprecation="true"
+>
+    <testsuites>
+        <testsuite name="contracts">
+            <directory suffix="Test.php">../packages/contracts/tests</directory>
+        </testsuite>
+        <testsuite name="core">
+            <directory suffix="Test.php">../packages/core/tests</directory>
+        </testsuite>
+        <testsuite name="http">
+            <directory suffix="Test.php">../packages/http/tests</directory>
+        </testsuite>
+        <testsuite name="module">
+            <directory suffix="Test.php">../packages/module/tests</directory>
+        </testsuite>
+        <testsuite name="plugin">
+            <directory suffix="Test.php">../packages/plugin/tests</directory>
+        </testsuite>
+        <testsuite name="testing">
+            <directory suffix="Test.php">../packages/testing/tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">../packages/contracts/src</directory>
+            <directory suffix=".php">../packages/core/src</directory>
+            <directory suffix=".php">../packages/http/src</directory>
+            <directory suffix=".php">../packages/module/src</directory>
+            <directory suffix=".php">../packages/plugin/src</directory>
+            <directory suffix=".php">../packages/testing/src</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
## Summary

Establishes the PHPUnit testing foundation for the EvolvePHP 2 workspace and its six packages.

## Changes

- adds PHPUnit `^13.2` as a workspace-only development dependency
- locks PHPUnit at `13.2.6`
- adds a PHP 8.4-compatible workspace PHPUnit configuration
- adds named test suites for contracts, core, HTTP, module, plugin, and testing
- adds Composer test scripts using Composer’s `@php` runtime
- adds one package-manifest smoke test per package
- updates the workspace Composer architecture policy for the Phase 2.3 requirements
- adds a dedicated Phase 2.3 architecture-policy test
- updates workspace documentation, package documentation, and the changelog

## Runtime separation

The legacy root test harness remains on PHP 8.3.

The EvolvePHP 2 workspace was resolved and tested using:

- PHP 8.4.23
- Composer 2.10.2
- PHPUnit 13.2.6

Workspace Composer scripts use `@php`, ensuring they run with the PHP binary executing Composer without requiring users to modify `PATH`.

## Validation

### Root regression suite

- 101 tests
- 1208 assertions

### Root architecture suite

- 25 tests
- 454 assertions

### Documentation suite

- 76 tests
- 754 assertions

### Workspace PHPUnit suite

- 6 tests
- 18 assertions

### Individual package suites

Each package suite passes with:

- 1 test
- 3 assertions

### Composer validation

- workspace Composer manifest and lockfile pass strict validation
- all six package Composer manifests pass strict validation
- root Composer manifest remains valid with its existing version warning

## Scope protection

- root `composer.json` unchanged
- root `composer.lock` unchanged
- root `phpunit.xml.dist` unchanged
- all six package Composer manifests unchanged
- no vendor files tracked
- no platform-requirement bypass used
- no runtime implementation added
- no static analysis, coding standards, CI, security scanning, coverage policy, or Phase 2.4 work included