### PR TITLE
architecture: enforce package dependency boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.lock
 /workspace/vendor/
 /workspace/.phpstan-cache/
 /workspace/.php-cs-fixer.cache
+/workspace/.deptrac.cache
 /workspace/phpstan.neon
 /workspace/.php-cs-fixer.php
 /logs/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation and governance
 
+- Added Phase 2.5 workspace-owned Deptrac architecture and dependency-boundary enforcement for the initial EvolvePHP 2 package graph.
 - Added Phase 2.4 workspace-owned PHPStan level 6 static analysis, PHPUnit type-inference integration, PHP-CS-Fixer PER Coding Style 3.0 checks, and architecture-policy tests for cache, baseline and tooling ownership.
 - Added Phase 2.3 PHPUnit 13 workspace foundation, six package test suites, and the initial workspace lockfile generated under PHP 8.4.
 - Added Phase 2.2 dedicated EvolvePHP 2 Composer workspace with local path-repository integration and explicit 2.0.x-dev package version mapping.

--- a/README.md
+++ b/README.md
@@ -184,18 +184,6 @@ Recommended `composer.json` description:
 }
 ```
 
-Also correct any misspelled keyword such as:
-
-```text
-elvovephp framework
-```
-
-to:
-
-```text
-evolvephp framework
-```
-
 ## Author
 
 **Josiah Gerald**

--- a/packages/README.md
+++ b/packages/README.md
@@ -62,4 +62,32 @@ Phase 2.4 adds workspace-owned static analysis and coding-standard tooling witho
 
 PHP-CS-Fixer checks package `src` and `tests` files using PER Coding Style 3.0 through `@PER-CS3x0`, with alphabetical import ordering and unused-import removal. The mutating `style:fix` command remains separate from the non-mutating `quality` command. Preserved EvolvePHP 1 root files are excluded from Phase 2.4 style checks.
 
+Phase 2.5 adds workspace-owned dependency-boundary enforcement through the maintained `deptrac/deptrac` package. The abandoned `qossmic/deptrac` package identity is prohibited.
+
+Deptrac analyzes production source directories only during Phase 2.5. Package tests are excluded from Phase 2.5 boundary analysis so test dependencies cannot weaken production rules. Physical package paths define the six layers, and package namespaces must match those paths:
+
+```text
+Contracts -> ../packages/contracts/src/.* -> Evolve\Contracts\
+Core      -> ../packages/core/src/.*      -> Evolve\Core\
+Http      -> ../packages/http/src/.*      -> Evolve\Http\
+Module    -> ../packages/module/src/.*    -> Evolve\Module\
+Plugin    -> ../packages/plugin/src/.*    -> Evolve\Plugin\
+Testing   -> ../packages/testing/src/.*   -> Evolve\Testing\
+```
+
+The enforced matrix is:
+
+```text
+Contracts -> none
+Core      -> Contracts
+Http      -> Contracts, Core
+Module    -> Contracts
+Plugin    -> Contracts
+Testing   -> Contracts, Core, Http, Module, Plugin
+```
+
+There is no production dependency on Testing. The `architecture` command is non-mutating, reports uncovered dependencies, and uncovered dependencies fail. It uses no baseline or skipped violations, and generates no graph. The temporary forbidden-edge probe used during Phase 2.5 validation is evidence only and is not committed. New external dependencies require explicit architecture review.
+
 Real PHP 8.4 and PHP 8.5 CI evidence is required before compatibility is claimed. Composer manifest validation under another local PHP version does not establish EvolvePHP 2 runtime compatibility.
+
+PHP 8.5 execution remains deferred to Phase 2.6.

--- a/tests/Architecture/EvolvePhp2ArchitectureAndDependencyBoundariesTest.php
+++ b/tests/Architecture/EvolvePhp2ArchitectureAndDependencyBoundariesTest.php
@@ -1,0 +1,338 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class EvolvePhp2ArchitectureAndDependencyBoundariesTest extends TestCase
+{
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testWorkspaceOwnsDeptracAsTheOnlyArchitectureBoundaryDependency(): void
+    {
+        $workspaceManifest = $this->readJsonFile('workspace/composer.json');
+
+        $this->assertArrayHasKey('require-dev', $workspaceManifest);
+        $this->assertArrayHasKey('deptrac/deptrac', $workspaceManifest['require-dev']);
+        $this->assertSame('^4.7', $workspaceManifest['require-dev']['deptrac/deptrac']);
+        $this->assertArrayNotHasKey('deptrac/deptrac', $workspaceManifest['require']);
+
+        $rootManifest = $this->readJsonFile('composer.json');
+        $this->assertPackageAbsentFromManifest('deptrac/deptrac', $rootManifest, 'composer.json');
+
+        foreach ($this->packageManifests() as $path) {
+            $this->assertPackageAbsentFromManifest('deptrac/deptrac', $this->readJsonFile($path), $path);
+        }
+
+        foreach (array('qossmic/deptrac', 'phparkitect/phparkitect', 'shipmonk/composer-dependency-analyser') as $package) {
+            $this->assertPackageAbsentFromManifest($package, $workspaceManifest, 'workspace/composer.json');
+            $this->assertPackageAbsentFromManifest($package, $rootManifest, 'composer.json');
+
+            foreach ($this->packageManifests() as $path) {
+                $this->assertPackageAbsentFromManifest($package, $this->readJsonFile($path), $path);
+            }
+        }
+    }
+
+    public function testWorkspaceDeclaresExactNonMutatingArchitectureScriptAndQualityPipeline(): void
+    {
+        $manifest = $this->readJsonFile('workspace/composer.json');
+        $scripts = $manifest['scripts'];
+
+        $expectedArchitecture = '@php vendor/bin/deptrac analyse --config-file=deptrac.php --no-progress --report-uncovered --fail-on-uncovered';
+        $this->assertArrayHasKey('architecture', $scripts);
+        $this->assertSame($expectedArchitecture, $scripts['architecture']);
+        $this->assertStringStartsWith('@php ', $scripts['architecture']);
+        $this->assertStringContainsString('vendor/bin/deptrac', $scripts['architecture']);
+        $this->assertStringContainsString('deptrac.php', $scripts['architecture']);
+        $this->assertStringContainsString('--no-progress', $scripts['architecture']);
+        $this->assertStringContainsString('--report-uncovered', $scripts['architecture']);
+        $this->assertStringContainsString('--fail-on-uncovered', $scripts['architecture']);
+
+        foreach (array(' init', ' baseline', ' graph', ' debug', '--formatter=baseline', '--formatter=graphviz', '--formatter=mermaid') as $mutatingOrGeneratedCommand) {
+            $this->assertStringNotContainsString($mutatingOrGeneratedCommand, $scripts['architecture']);
+        }
+
+        $expectedQuality = array('@architecture', '@analyse', '@style:check', '@test');
+        $this->assertArrayHasKey('quality', $scripts);
+        $this->assertSame($expectedQuality, $scripts['quality']);
+        $this->assertSame('@architecture', $scripts['quality'][0], 'architecture must run first in quality.');
+        $this->assertSame($scripts['quality'], array_values(array_unique($scripts['quality'])));
+        $this->assertNotContains('@style:fix', $scripts['quality']);
+
+        foreach ($scripts['quality'] as $entry) {
+            foreach (array('baseline', 'graph', 'debug', 'security', 'ci') as $forbidden) {
+                $this->assertStringNotContainsString($forbidden, strtolower($entry));
+            }
+        }
+    }
+
+    public function testDeptracConfigurationIsWorkspaceOwnedAndStrict(): void
+    {
+        $this->assertFileExists($this->projectPath('workspace/deptrac.php'));
+
+        $trackedFiles = $this->trackedFiles();
+        $forbiddenBasenameAlternatives = array(
+            'deptrac.yaml',
+            'deptrac.yml',
+            'deptrac.yaml.dist',
+            'deptrac.baseline.yaml',
+            'deptrac.baseline.yml',
+            'deptrac-baseline.php',
+        );
+
+        foreach ($trackedFiles as $file) {
+            $normalized = str_replace('\\', '/', $file);
+
+            $this->assertNotContains(basename($normalized), $forbiddenBasenameAlternatives, $normalized . ' must not be tracked.');
+        }
+
+        $gitignore = $this->readProjectFile('.gitignore');
+        $this->assertStringContainsString('/workspace/.deptrac.cache', $gitignore);
+        $this->assertNotContains('workspace/.deptrac.cache', $trackedFiles, 'Deptrac cache must not be tracked.');
+
+        $content = $this->readProjectFile('workspace/deptrac.php');
+
+        foreach ($this->expectedLayers() as $layerName => $pathPattern) {
+            $this->assertMatchesPattern('/Layer::withName\(\'' . preg_quote($layerName, '/') . '\'/', $content);
+            $this->assertStringContainsString("DirectoryConfig::create('" . $pathPattern . "')", $content);
+        }
+
+        $this->assertSame($this->expectedLayers(), $this->deptracLayerDirectories($content));
+        $this->assertSame($this->expectedRulesets(), $this->deptracRulesets($content));
+
+        foreach (array('../packages/contracts/tests', '../packages/core/tests', '../packages/http/tests', '../packages/module/tests', '../packages/plugin/tests', '../packages/testing/tests') as $testPath) {
+            $this->assertStringNotContainsString($testPath, $content);
+        }
+
+        foreach (array('baseline', 'skipViolations', 'skip_violations', 'imports', 'Graphviz', 'Mermaid', 'formatter', 'FeatureFlagsConfig', 'phpstanParser', 'ComposerConfig', 'CollectorInterface', 'services(') as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $content);
+        }
+    }
+
+    public function testProductionNamespacesMatchPhysicalPackageOwnership(): void
+    {
+        foreach ($this->packageSourceRules() as $directory => $namespacePrefix) {
+            foreach ($this->trackedPhpFilesUnder($directory) as $file) {
+                $content = $this->readProjectFile($file);
+
+                $this->assertMatchesPattern(
+                    '/^namespace\s+' . preg_quote(rtrim($namespacePrefix, '\\'), '/') . '(?:\\\\|;)/m',
+                    $content
+                );
+            }
+        }
+    }
+
+    public function testPhase25DoesNotCommitRuntimeImplementationOrGeneratedArchitectureArtifacts(): void
+    {
+        foreach (array_keys($this->packageSourceRules()) as $directory) {
+            $phpFiles = $this->trackedPhpFilesUnder($directory);
+
+            $this->assertSame(array(), $phpFiles, $directory . ' must remain free from runtime implementation PHP files in Phase 2.5.');
+        }
+
+        foreach ($this->trackedFiles() as $file) {
+            $normalized = str_replace('\\', '/', $file);
+            $lower = strtolower($normalized);
+
+            $this->assertDoesNotMatchPattern('/deptrac.*baseline/', $lower);
+            $this->assertDoesNotMatchPattern('/deptrac.*graph/', $lower);
+            $this->assertDoesNotMatchPattern('/Phase25.*BoundaryProbe/', $normalized);
+        }
+    }
+
+    public function testDocumentationRecordsArchitectureBoundaryPolicy(): void
+    {
+        $workspaceReadme = $this->readProjectFile('workspace/README.md');
+        $packagesReadme = $this->readProjectFile('packages/README.md');
+        $changelog = $this->readProjectFile('CHANGELOG.md');
+
+        foreach (array($workspaceReadme, $packagesReadme) as $content) {
+            $this->assertMatchesPattern('/deptrac\/deptrac/i', $content);
+            $this->assertMatchesPattern('/qossmic\/deptrac/i', $content);
+            $this->assertMatchesPattern('/production source directories/i', $content);
+            $this->assertMatchesPattern('/tests? (?:are|is) excluded|excluded from Phase 2\.5/i', $content);
+            $this->assertMatchesPattern('/physical package paths?/i', $content);
+            $this->assertMatchesPattern('/no production dependency on Testing/i', $content);
+            $this->assertMatchesPattern('/uncovered dependencies fail/i', $content);
+            $this->assertMatchesPattern('/no baseline|baseline.*not/i', $content);
+            $this->assertMatchesPattern('/no graph|graph.*not/i', $content);
+            $this->assertMatchesPattern('/PHP 8\.5.*Phase 2\.6/i', $content);
+        }
+
+        $this->assertMatchesPattern('/Phase 2\.5/i', $changelog);
+        $this->assertMatchesPattern('/Deptrac/i', $changelog);
+        $this->assertMatchesPattern('/dependency-boundar/i', $changelog);
+    }
+
+    private function expectedLayers()
+    {
+        return array(
+            'Contracts' => '../packages/contracts/src/.*',
+            'Core' => '../packages/core/src/.*',
+            'Http' => '../packages/http/src/.*',
+            'Module' => '../packages/module/src/.*',
+            'Plugin' => '../packages/plugin/src/.*',
+            'Testing' => '../packages/testing/src/.*',
+        );
+    }
+
+    private function expectedRulesets()
+    {
+        return array(
+            'Contracts' => array(),
+            'Core' => array('Contracts'),
+            'Http' => array('Contracts', 'Core'),
+            'Module' => array('Contracts'),
+            'Plugin' => array('Contracts'),
+            'Testing' => array('Contracts', 'Core', 'Http', 'Module', 'Plugin'),
+        );
+    }
+
+    private function deptracLayerDirectories($content)
+    {
+        $layers = array();
+        $pattern = "/\\$(\\w+)\\s*=\\s*Layer::withName\\('([^']+)'\\)->collectors\\(\\s*DirectoryConfig::create\\('([^']+)'\\),\\s*\\)/s";
+
+        preg_match_all($pattern, $content, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $layers[$match[2]] = $match[3];
+        }
+
+        return $layers;
+    }
+
+    private function deptracRulesets($content)
+    {
+        $variablesByLayer = array(
+            'contracts' => 'Contracts',
+            'core' => 'Core',
+            'http' => 'Http',
+            'module' => 'Module',
+            'plugin' => 'Plugin',
+            'testing' => 'Testing',
+        );
+        $rulesets = array();
+
+        foreach ($variablesByLayer as $variable => $layerName) {
+            $pattern = '/Ruleset::forLayer\\(\\$' . $variable . '\\)(?:->accesses\\((.*?)\\))?/s';
+            $this->assertSame(1, preg_match($pattern, $content, $match), 'Missing ruleset for ' . $layerName . '.');
+            $accesses = array();
+
+            if (isset($match[1])) {
+                preg_match_all('/\\$(contracts|core|http|module|plugin|testing)\\b/', $match[1], $accessMatches);
+
+                foreach ($accessMatches[1] as $accessVariable) {
+                    $accesses[] = $variablesByLayer[$accessVariable];
+                }
+            }
+
+            $rulesets[$layerName] = $accesses;
+        }
+
+        foreach (array('Contracts', 'Core', 'Http', 'Module', 'Plugin') as $productionLayer) {
+            $this->assertNotContains('Testing', $rulesets[$productionLayer], $productionLayer . ' must not access Testing.');
+        }
+
+        return $rulesets;
+    }
+
+    private function packageSourceRules()
+    {
+        return array(
+            'packages/contracts/src' => 'Evolve\\Contracts\\',
+            'packages/core/src' => 'Evolve\\Core\\',
+            'packages/http/src' => 'Evolve\\Http\\',
+            'packages/module/src' => 'Evolve\\Module\\',
+            'packages/plugin/src' => 'Evolve\\Plugin\\',
+            'packages/testing/src' => 'Evolve\\Testing\\',
+        );
+    }
+
+    private function packageManifests()
+    {
+        return array(
+            'packages/contracts/composer.json',
+            'packages/core/composer.json',
+            'packages/http/composer.json',
+            'packages/module/composer.json',
+            'packages/plugin/composer.json',
+            'packages/testing/composer.json',
+        );
+    }
+
+    private function assertPackageAbsentFromManifest($package, array $manifest, $path): void
+    {
+        $this->assertArrayNotHasKey($package, isset($manifest['require']) ? $manifest['require'] : array(), $path . ' must not require ' . $package . '.');
+        $this->assertArrayNotHasKey($package, isset($manifest['require-dev']) ? $manifest['require-dev'] : array(), $path . ' must not require-dev ' . $package . '.');
+    }
+
+    private function trackedPhpFilesUnder($directory)
+    {
+        $files = array();
+        $prefix = rtrim(str_replace('\\', '/', $directory), '/') . '/';
+
+        foreach ($this->trackedFiles() as $file) {
+            $normalized = str_replace('\\', '/', $file);
+
+            if (strpos($normalized, $prefix) === 0 && substr($normalized, -4) === '.php') {
+                $files[] = $normalized;
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function trackedFiles()
+    {
+        $output = array();
+        $exitCode = 0;
+
+        exec('git ls-files', $output, $exitCode);
+
+        $this->assertSame(0, $exitCode, 'git ls-files should succeed.');
+
+        return $output;
+    }
+
+    private function projectPath($path)
+    {
+        return $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    private function readProjectFile($path)
+    {
+        $fullPath = $this->projectPath($path);
+        $this->assertFileExists($fullPath, $path . ' should exist before it is read.');
+
+        return file_get_contents($fullPath);
+    }
+
+    private function readJsonFile($path)
+    {
+        $content = $this->readProjectFile($path);
+        $json = json_decode($content, true);
+
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), $path . ' should contain valid JSON: ' . json_last_error_msg());
+        $this->assertIsArray($json, $path . ' should decode to a JSON object.');
+
+        return $json;
+    }
+
+    private function assertMatchesPattern($pattern, $content): void
+    {
+        $this->assertSame(1, preg_match($pattern, $content), 'Failed asserting that content matches ' . $pattern);
+    }
+
+    private function assertDoesNotMatchPattern($pattern, $content): void
+    {
+        $this->assertSame(0, preg_match($pattern, $content), 'Failed asserting that content does not match ' . $pattern);
+    }
+}

--- a/tests/Architecture/EvolvePhp2StaticAnalysisAndCodingStandardsTest.php
+++ b/tests/Architecture/EvolvePhp2StaticAnalysisAndCodingStandardsTest.php
@@ -11,26 +11,21 @@ final class EvolvePhp2StaticAnalysisAndCodingStandardsTest extends TestCase
         $this->root = dirname(__DIR__, 2);
     }
 
-    public function testWorkspaceOwnsExactApprovedQualityDevelopmentDependencies(): void
+    public function testWorkspaceOwnsApprovedStaticAnalysisAndCodingStandardsDevelopmentDependencies(): void
     {
         $manifest = $this->readJsonFile('workspace/composer.json');
 
-        $expectedRequireDev = array(
-            'evolvephp/testing' => '^2.0@dev',
+        $expectedQualityRequireDev = array(
             'friendsofphp/php-cs-fixer' => '^3.95',
             'phpstan/phpstan' => '^2.2',
             'phpstan/phpstan-phpunit' => '^2.0',
-            'phpunit/phpunit' => '^13.2',
         );
 
-        $actualRequireDev = $manifest['require-dev'];
+        $this->assertArrayHasKey('require-dev', $manifest);
 
-        ksort($expectedRequireDev);
-        ksort($actualRequireDev);
-
-        $this->assertSame($expectedRequireDev, $actualRequireDev);
-
-        foreach ($this->qualityPackages() as $package) {
+        foreach ($expectedQualityRequireDev as $package => $constraint) {
+            $this->assertArrayHasKey($package, $manifest['require-dev']);
+            $this->assertSame($constraint, $manifest['require-dev'][$package]);
             $this->assertArrayNotHasKey($package, $manifest['require'], $package . ' must be development-only.');
         }
     }
@@ -57,39 +52,35 @@ final class EvolvePhp2StaticAnalysisAndCodingStandardsTest extends TestCase
         }
     }
 
-    public function testWorkspaceScriptsDeclareExactQualityAndPhpUnitCommandMap(): void
+    public function testWorkspaceScriptsDeclareApprovedStaticAnalysisAndCodingStandardsCommands(): void
     {
         $manifest = $this->readJsonFile('workspace/composer.json');
 
         $expectedScripts = array(
             'analyse' => '@php vendor/bin/phpstan analyse --configuration phpstan.neon.dist --no-progress',
-            'quality' => array(
-                '@analyse',
-                '@style:check',
-                '@test',
-            ),
             'style:check' => '@php vendor/bin/php-cs-fixer check --config=.php-cs-fixer.dist.php --diff --verbose',
             'style:fix' => '@php vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --verbose',
-            'test' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist',
-            'test:contracts' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite contracts',
-            'test:core' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite core',
-            'test:http' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite http',
-            'test:module' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite module',
-            'test:plugin' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite plugin',
-            'test:testing' => '@php vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite testing',
         );
 
         $actualScripts = $manifest['scripts'];
 
-        ksort($expectedScripts);
-        ksort($actualScripts);
-
-        $this->assertSame($expectedScripts, $actualScripts);
-        $this->assertNotContains('@style:fix', $actualScripts['quality'], 'quality must remain non-mutating.');
-
-        foreach (array('analyse', 'style:check', 'style:fix', 'test', 'test:contracts', 'test:core', 'test:http', 'test:module', 'test:plugin', 'test:testing') as $scriptName) {
+        foreach ($expectedScripts as $scriptName => $script) {
+            $this->assertArrayHasKey($scriptName, $actualScripts);
+            $this->assertSame($script, $actualScripts[$scriptName]);
             $this->assertStringStartsWith('@php ', $actualScripts[$scriptName], $scriptName . ' must use Composer @php.');
         }
+
+        $this->assertArrayHasKey('quality', $actualScripts);
+        $this->assertIsArray($actualScripts['quality']);
+        $this->assertContains('@analyse', $actualScripts['quality']);
+        $this->assertContains('@style:check', $actualScripts['quality']);
+        $this->assertContains('@test', $actualScripts['quality']);
+        $this->assertNotContains('@style:fix', $actualScripts['quality'], 'quality must remain non-mutating.');
+        $this->assertSame(
+            $actualScripts['quality'],
+            array_values(array_unique($actualScripts['quality'])),
+            'quality must not contain duplicate entries.'
+        );
     }
 
     public function testConfigurationFilesAreOwnedByWorkspaceAndNoTrackedAlternativesExist(): void

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -36,12 +36,15 @@ Quality tooling is also listed in `require-dev` and is owned only by this worksp
 - `phpstan/phpstan`
 - `phpstan/phpstan-phpunit`
 - `friendsofphp/php-cs-fixer`
+- `deptrac/deptrac`
 
 Production packages remain independent of `evolvephp/testing`.
 
 PHPUnit 13 is owned by the EvolvePHP 2 workspace. It must not be added to the legacy root Composer manifest, any package manifest or production requirements.
 
 PHPStan and PHP-CS-Fixer are also workspace-only development tools. They must not be added to the legacy root Composer manifest, any package manifest or production requirements.
+
+Deptrac is also workspace-owned development tooling. The maintained package identity is `deptrac/deptrac`; the abandoned `qossmic/deptrac` package identity is prohibited.
 
 ## Local Commands
 
@@ -83,6 +86,14 @@ Run static analysis:
 composer --working-dir=workspace analyse
 ```
 
+Run architecture and dependency-boundary validation:
+
+```bash
+composer --working-dir=workspace architecture
+```
+
+`architecture` is non-mutating. It analyzes production source directories only, reports uncovered dependencies, and uncovered dependencies fail. It uses no baseline or skipped violations, and does not generate a graph.
+
 Run coding-standard checks:
 
 ```bash
@@ -103,7 +114,7 @@ Run non-mutating workspace quality validation:
 composer --working-dir=workspace quality
 ```
 
-`quality` calls `analyse`, `style:check` and `test`. It does not call `style:fix`.
+`quality` calls `architecture`, `analyse`, `style:check` and `test`, in that order. Architecture runs first so package-boundary violations stop the pipeline before later quality checks. It does not call `style:fix`.
 
 Workspace Composer scripts use Composer's `@php` so vendor tools run under the PHP binary selected by the Composer execution environment. On the PHP 8.4 workspace, Composer84 uses `D:\php-84\php.exe`.
 
@@ -155,6 +166,51 @@ The workspace manually includes `phpstan/phpstan-phpunit` type-inference integra
 
 No PHPStan baseline is allowed initially, and the configuration must not use `ignoreErrors`. Local PHPStan cache belongs in `workspace/.phpstan-cache/` and is ignored.
 
+## Architecture Boundaries
+
+Deptrac is the Phase 2.5 architecture-boundary engine. The configuration lives at:
+
+```text
+workspace/deptrac.php
+```
+
+Phase 2.5 analyzes the six package production source directories only:
+
+```text
+../packages/contracts/src
+../packages/core/src
+../packages/http/src
+../packages/module/src
+../packages/plugin/src
+../packages/testing/src
+```
+
+Package tests are excluded from Phase 2.5 boundary analysis so test dependencies cannot weaken production rules. Physical package paths define layers, and package namespaces must match the package paths:
+
+```text
+Contracts -> ../packages/contracts/src/.* -> Evolve\Contracts\
+Core      -> ../packages/core/src/.*      -> Evolve\Core\
+Http      -> ../packages/http/src/.*      -> Evolve\Http\
+Module    -> ../packages/module/src/.*    -> Evolve\Module\
+Plugin    -> ../packages/plugin/src/.*    -> Evolve\Plugin\
+Testing   -> ../packages/testing/src/.*   -> Evolve\Testing\
+```
+
+The accepted dependency matrix is:
+
+```text
+Contracts -> none
+Core      -> Contracts
+Http      -> Contracts, Core
+Module    -> Contracts
+Plugin    -> Contracts
+Testing   -> Contracts, Core, Http, Module, Plugin
+```
+
+There is no production dependency on Testing. Testing may depend on all five production packages.
+
+New external dependencies require explicit architecture review instead of being silently accepted. No architecture baseline, skipped violations or generated graph is allowed in Phase 2.5. Local Deptrac cache belongs in `workspace/.deptrac.cache` and is ignored. The temporary forbidden-edge probe used during Phase 2.5 validation is evidence only and is not committed.
+
 ## Coding Standards
 
 PHP-CS-Fixer is the workspace coding-standard engine. The distributable configuration lives at:
@@ -183,7 +239,6 @@ Future changes to workspace dependencies must update the lockfile through Compos
 
 The following remain deferred:
 
-- Dependency-boundary tooling
 - GitHub Actions
 - PHP 8.5 CI verification to Phase 2.6
 - Security and licence scanning

--- a/workspace/composer.json
+++ b/workspace/composer.json
@@ -29,6 +29,7 @@
         "evolvephp/plugin": "^2.0@dev"
     },
     "require-dev": {
+        "deptrac/deptrac": "^4.7",
         "evolvephp/testing": "^2.0@dev",
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.2",
@@ -36,8 +37,10 @@
         "phpunit/phpunit": "^13.2"
     },
     "scripts": {
+        "architecture": "@php vendor/bin/deptrac analyse --config-file=deptrac.php --no-progress --report-uncovered --fail-on-uncovered",
         "analyse": "@php vendor/bin/phpstan analyse --configuration phpstan.neon.dist --no-progress",
         "quality": [
+            "@architecture",
             "@analyse",
             "@style:check",
             "@test"

--- a/workspace/composer.lock
+++ b/workspace/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "688f0badecb8c1126627b736bd2d8aa6",
+    "content-hash": "62671ed95015905a8c1d43feed0e7afc",
     "packages": [
         {
             "name": "evolvephp/contracts",
@@ -422,6 +422,139 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "deptrac/deptrac",
+            "version": "4.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deptrac/deptrac.git",
+                "reference": "de3303ae1e280b1e58552fef496074b4ee5b143b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deptrac/deptrac/zipball/de3303ae1e280b1e58552fef496074b4ee5b143b",
+                "reference": "de3303ae1e280b1e58552fef496074b4ee5b143b",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^3.0",
+                "jetbrains/phpstorm-stubs": "2024.3 || 2025.3 || 2026.1",
+                "nikic/php-parser": "^5",
+                "php": "^8.2",
+                "phpdocumentor/graphviz": "^2.1",
+                "phpdocumentor/type-resolver": "^1.9.0 || ^2.0.0",
+                "phpstan/phpdoc-parser": "^1.5.0 || ^2.1.0",
+                "phpstan/phpstan": "^2.0",
+                "psr/container": "^2.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/config": "^6.4 || ^7.4 || ^8.0",
+                "symfony/console": "^6.4 || ^7.4 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.4 || ^8.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.4 || ^8.0",
+                "symfony/event-dispatcher-contracts": "^3.4",
+                "symfony/filesystem": "^6.4 || ^7.4 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.4 || ^8.0",
+                "symfony/yaml": "^6.4 || ^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8",
+                "ergebnis/composer-normalize": "^2.45",
+                "ext-libxml": "*",
+                "symfony/stopwatch": "^6.4 || ^7.4 || ^8.0"
+            },
+            "suggest": {
+                "ext-dom": "For using the JUnit output formatter"
+            },
+            "bin": [
+                "deptrac"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Deptrac\\Deptrac\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Glabisch"
+                },
+                {
+                    "name": "Simon Mönch"
+                },
+                {
+                    "name": "Denis Brumann"
+                }
+            ],
+            "description": "Deptrac is a static code analysis tool that helps to enforce rules for dependencies between software layers.",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/deptrac/deptrac/issues",
+                "source": "https://github.com/deptrac/deptrac/tree/4.7.1"
+            },
+            "time": "2026-07-23T20:41:37+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
             "name": "ergebnis/agent-detector",
             "version": "1.2.0",
             "source": {
@@ -734,6 +867,50 @@
             "time": "2026-07-30T15:46:02+00:00"
         },
         {
+            "name": "jetbrains/phpstorm-stubs",
+            "version": "v2026.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JetBrains/phpstorm-stubs",
+                "reference": "2cdd054c4109dfb76667c9198bf9427606354243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/2cdd054c4109dfb76667c9198bf9427606354243",
+                "reference": "2cdd054c4109dfb76667c9198bf9427606354243",
+                "shasum": ""
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.86",
+                "nikic/php-parser": "^v5.6",
+                "phpdocumentor/reflection-docblock": "^5.6",
+                "phpunit/phpunit": "^12.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpStormStubsMap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "PHP runtime & extensions header files for PhpStorm",
+            "homepage": "https://www.jetbrains.com/phpstorm",
+            "keywords": [
+                "autocomplete",
+                "code",
+                "inference",
+                "inspection",
+                "jetbrains",
+                "phpstorm",
+                "stubs",
+                "type"
+            ],
+            "time": "2026-02-19T20:12:01+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -967,6 +1144,217 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/graphviz",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/GraphViz.git",
+                "reference": "115999dc7f31f2392645aa825a94a6b165e1cedf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/GraphViz/zipball/115999dc7f31f2392645aa825a94a6b165e1cedf",
+                "reference": "115999dc7f31f2392645aa825a94a6b165e1cedf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "mockery/mockery": "^1.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^8.2 || ^9.2",
+                "psalm/phar": "^4.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\GraphViz\\": "src/phpDocumentor/GraphViz",
+                    "phpDocumentor\\GraphViz\\PHPStan\\": "./src/phpDocumentor/PHPStan"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "description": "Wrapper for Graphviz",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/GraphViz/issues",
+                "source": "https://github.com/phpDocumentor/GraphViz/tree/2.1.0"
+            },
+            "time": "2021-12-13T19:03:21+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3404,6 +3792,84 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/config",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "e8ee277684fa228d37795ff160b901eeda1ade5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e8ee277684fa228d37795ff160b901eeda1ade5d",
+                "reference": "e8ee277684fa228d37795ff160b901eeda1ade5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-22T15:42:13+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v8.1.2",
             "source": {
@@ -3502,6 +3968,87 @@
                 }
             ],
             "time": "2026-07-27T13:58:19+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "9bc6af9fadb6e7a614606e82e040fd4ac95c1d42"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/9bc6af9fadb6e7a614606e82e040fd4ac95c1d42",
+                "reference": "9bc6af9fadb6e7a614606e82e040fd4ac95c1d42",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^3.6",
+                "symfony/var-exporter": "^8.1"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T13:31:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4032,6 +4579,93 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-deepclone",
+            "version": "v1.40.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-deepclone.git",
+                "reference": "dca4ccba5f360070b574414dce4c1e7a559844fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-deepclone/zipball/dca4ccba5f360070b574414dce4c1e7a559844fa",
+                "reference": "dca4ccba5f360070b574414dce4c1e7a559844fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "provide": {
+                "ext-deepclone": "*"
+            },
+            "suggest": {
+                "ext-deepclone": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\DeepClone\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the deepclone extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "deepclone",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-deepclone/tree/v1.40.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-12T07:27:17+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -4916,6 +5550,165 @@
                 }
             ],
             "time": "2026-07-28T07:35:25+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v8.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "766dac532a04d8980b4d83183fd3d1ea284bac11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/766dac532a04d8980b4d83183fd3d1ea284bac11",
+                "reference": "766dac532a04d8980b4d83183fd3d1ea284bac11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-deepclone": "^1.40"
+            },
+            "require-dev": {
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to export, instantiate, hydrate, clone and lazy-load PHP objects",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "deep-clone",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v8.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-29T16:43:23+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "faabdbe998e8c5c599dceffa27aa265b185c0736"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/faabdbe998e8c5c599dceffa27aa265b185c0736",
+                "reference": "faabdbe998e8c5c599dceffa27aa265b185c0736",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-22T15:42:13+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/workspace/deptrac.php
+++ b/workspace/deptrac.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Deptrac\Deptrac\Contract\Config\Collector\DirectoryConfig;
+use Deptrac\Deptrac\Contract\Config\DeptracConfig;
+use Deptrac\Deptrac\Contract\Config\Layer;
+use Deptrac\Deptrac\Contract\Config\Ruleset;
+
+return static function (DeptracConfig $config): void {
+    $config
+        ->paths(
+            '../packages/contracts/src',
+            '../packages/core/src',
+            '../packages/http/src',
+            '../packages/module/src',
+            '../packages/plugin/src',
+            '../packages/testing/src',
+        )
+        ->cacheFile(__DIR__ . '/.deptrac.cache')
+        ->layers(
+            $contracts = Layer::withName('Contracts')->collectors(
+                DirectoryConfig::create('../packages/contracts/src/.*'),
+            ),
+            $core = Layer::withName('Core')->collectors(
+                DirectoryConfig::create('../packages/core/src/.*'),
+            ),
+            $http = Layer::withName('Http')->collectors(
+                DirectoryConfig::create('../packages/http/src/.*'),
+            ),
+            $module = Layer::withName('Module')->collectors(
+                DirectoryConfig::create('../packages/module/src/.*'),
+            ),
+            $plugin = Layer::withName('Plugin')->collectors(
+                DirectoryConfig::create('../packages/plugin/src/.*'),
+            ),
+            $testing = Layer::withName('Testing')->collectors(
+                DirectoryConfig::create('../packages/testing/src/.*'),
+            ),
+        )
+        ->rulesets(
+            Ruleset::forLayer($contracts),
+            Ruleset::forLayer($core)->accesses($contracts),
+            Ruleset::forLayer($http)->accesses($contracts, $core),
+            Ruleset::forLayer($module)->accesses($contracts),
+            Ruleset::forLayer($plugin)->accesses($contracts),
+            Ruleset::forLayer($testing)->accesses(
+                $contracts,
+                $core,
+                $http,
+                $module,
+                $plugin,
+            ),
+        );
+};


### PR DESCRIPTION
## Summary

Adds architecture and dependency-boundary enforcement for the EvolvePHP 2 package workspace.

## Changes

- adds maintained `deptrac/deptrac` `^4.7` to workspace development tooling
- resolves Deptrac `4.7.1`
- adds six physical package-source layers
- enforces the accepted inward package dependency graph
- prohibits production dependencies on the Testing package
- reports and fails on uncovered dependencies
- adds a non-mutating `architecture` Composer command
- runs architecture validation first in the aggregate `quality` command
- adds architecture-policy tests
- narrows Phase 2.4 policy ownership to PHPStan and PHP-CS-Fixer
- ignores the local Deptrac cache
- documents architecture-tool ownership and boundary policy
- removes a stray internal editing instruction containing the misspelling `elvovephp framework` from the public root README

## Package Boundary Matrix

```text
Contracts -> none

Core -> Contracts

Http -> Contracts, Core

Module -> Contracts

Plugin -> Contracts

Testing -> Contracts, Core, Http, Module, Plugin