### PR TITLE
docs: add repository branch governance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,15 +42,23 @@ Rules:
 ## 4. Legacy preservation
 
 - `master` represents the EvolvePHP 1 legacy line.
+- `master` is reserved for preserved EvolvePHP 1 history and explicitly approved legacy maintenance.
+- EvolvePHP 1 maintenance must be clearly requested.
+- An approved legacy-maintenance task must start from `master`, then continue on its own task-specific branch.
 - Do not modernise EvolvePHP 1 unless a task explicitly targets legacy maintenance.
 - Do not silently fix historical issues during documentation work.
 - Preserve historical evidence and clearly document limitations.
 - EvolvePHP 2 development must occur separately from the preserved legacy baseline.
+- EvolvePHP 2 work is based on the current `2.x` branch.
+- EvolvePHP 2 changes must never be merged into `master`.
+- EvolvePHP 1 changes must not be silently mixed into `2.x`.
 
 ## 5. Branch safety
 
-- Do not work directly on `master`.
+- Do not work directly on `master`; direct work on `master` remains prohibited unless the task explicitly targets approved legacy maintenance, and approved legacy maintenance still requires a task-specific branch.
 - Confirm a clean working tree before editing.
+- Verify the requested base branch and exact base SHA before editing.
+- Agents must not infer the correct base branch from GitHub's current default branch.
 - Use a task-specific branch.
 - Do not push, merge, tag or open a pull request unless explicitly requested.
 - Never rewrite shared history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation and governance
 
+- Added Phase 2.7A repository-owned branch-governance policy foundation for EvolvePHP 2 development on `2.x`, preserved EvolvePHP 1 maintenance on `master`, explicit separation of modern development and legacy maintenance, and preparation for a later default-branch and ruleset transition.
 - Added Phase 2.6 GitHub Actions CI foundation with a PHP 8.4/8.5 workspace quality matrix, separate PHP 8.4 root-policy job, lockfile-based workspace installation, immutable action pinning, and successful initial CI execution for the current workspace, tooling and package foundation.
 - Added Phase 2.5.1 README and metadata consistency cleanup, aligning the EvolvePHP 2 README hierarchy, correcting root Composer metadata, deduplicating stale RFC index narration, removing duplicated phase history, and clarifying workspace installation and compatibility guidance.
 - Added Phase 2.5 workspace-owned Deptrac architecture and dependency-boundary enforcement for the initial EvolvePHP 2 package graph.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # EvolvePHP 2
 
-This branch contains the EvolvePHP 2 redesign on `2.x`.
+`2.x` is the designated EvolvePHP 2 development branch.
 
-EvolvePHP 1 remains preserved on `master` for historical reference and legacy maintenance. EvolvePHP 2 is not an in-place refactor of the EvolvePHP 1 runtime.
+`master` remains the preserved EvolvePHP 1 legacy branch for historical reference and explicitly approved legacy maintenance. EvolvePHP 2 development and proposed changes must not target `master`.
+
+During Phase 2.7A, the current GitHub default branch remains `master` until the Phase 2.7 external transition. The live default-branch and ruleset transition is still pending external GitHub evidence.
+
+EvolvePHP 2 is not an in-place refactor, replacement or rewrite of the EvolvePHP 1 runtime history.
 
 The current EvolvePHP 2 repository contains package boundaries, Composer workspace setup and quality-tooling foundations. Runtime framework implementation is not yet complete, and the packages are not yet published.
 
@@ -16,8 +20,10 @@ The EvolvePHP 2 line redesigns the framework as a modular package architecture w
 
 ## Current Status
 
-- Branch: `2.x`
+- EvolvePHP 2 development branch: `2.x`
+- Current GitHub default during Phase 2.7A: `master`
 - Legacy line: EvolvePHP 1 on `master`
+- Governance transition: live default-branch and ruleset changes pending external verification
 - Runtime implementation: not yet complete
 - Package publication: packages are not yet published
 - PHP baseline: PHP 8.4
@@ -77,7 +83,9 @@ The package architecture uses explicit namespace ownership and inward dependency
 
 EvolvePHP 1 has been used as the foundation of Africa Global Export Market, a live business-to-business export platform serving more than 5,000 users.
 
-That production-use background belongs to the preserved EvolvePHP 1 history. New EvolvePHP 2 work happens separately on `2.x`, and new production applications should not start from EvolvePHP 1 without a detailed security and compatibility review.
+That production-use background belongs to the preserved EvolvePHP 1 history. New EvolvePHP 2 work happens separately on `2.x`, and EvolvePHP 2 changes must not target `master`. New production applications should not start from EvolvePHP 1 without a detailed security and compatibility review.
+
+Phase 2.7A establishes repository-owned branch-governance policy only. `master` has not been renamed or deleted, no `main` branch has been created, and no `1.x` branch has been created. Any stable-release branch rename or promotion is deferred, and Phase 2.7 does not replace the legacy history.
 
 See the [legacy overview](docs/history/evolvephp-1-overview.md), [known risks and limitations](docs/history/known-risks-and-limitations.md), [support policy](SUPPORT.md) and [security policy](SECURITY.md).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,9 +10,9 @@ Use the appropriate channel for the type of request:
 
 ## Version status
 
-EvolvePHP 1 legacy support applies to the preserved `master` line. Maintainers may answer questions, review reports and consider narrowly scoped maintenance fixes, but EvolvePHP 1 is not recommended as the foundation for new production applications without a detailed security and compatibility review.
+EvolvePHP 1 legacy support applies to the preserved `master` line. `master` remains preserved as the EvolvePHP 1 legacy line. EvolvePHP 1 legacy maintenance belongs to `master` only when explicitly approved. Maintainers may answer questions, review reports and consider narrowly scoped maintenance fixes, but EvolvePHP 1 is not recommended as the foundation for new production applications without a detailed security and compatibility review.
 
-EvolvePHP 2 development is separate from EvolvePHP 1. EvolvePHP 2 is under development and should not be described as production-ready until a reviewed release says so.
+EvolvePHP 2 development is separate from EvolvePHP 1. EvolvePHP 2 reports and proposed changes target `2.x`; development changes for EvolvePHP 2 belong to `2.x`. New EvolvePHP 2 feature development does not target `master`. EvolvePHP 2 remains under development and is not production-ready until a reviewed release says so.
 
 ## What maintainers may support
 
@@ -23,7 +23,7 @@ Maintainers may reasonably support:
 - Reviewing security reports through the private process in `SECURITY.md`.
 - Accepting documentation improvements that preserve historical accuracy.
 - Considering narrowly scoped EvolvePHP 1 maintenance fixes when explicitly approved.
-- Planning EvolvePHP 2 design work separately from legacy preservation.
+- Planning EvolvePHP 2 design work and proposed changes on `2.x` separately from legacy preservation.
 
 ## Out of scope
 

--- a/tests/Documentation/EvolvePhp2RepositoryGovernanceTest.php
+++ b/tests/Documentation/EvolvePhp2RepositoryGovernanceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class EvolvePhp2RepositoryGovernanceTest extends TestCase
+{
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testReadmeDocumentsStageABranchIdentity()
+    {
+        $content = $this->readProjectFile('README.md');
+
+        $this->assertMatchesPattern('/2\.x.*designated EvolvePHP 2 development branch|designated EvolvePHP 2 development branch.*2\.x/is', $content);
+        $this->assertMatchesPattern('/master.*preserved EvolvePHP 1 legacy branch|preserved EvolvePHP 1 legacy branch.*master/is', $content);
+        $this->assertMatchesPattern('/EvolvePHP 2 changes.*must not target.*master|must not target.*master.*EvolvePHP 2 changes/is', $content);
+        $this->assertMatchesPattern('/current GitHub default.*master.*Phase 2\.7 external transition|Phase 2\.7 external transition.*current GitHub default.*master/is', $content);
+        $this->assertDoesNotMatchPattern($this->unsupportedDefaultBranchClaimPattern(), $content);
+    }
+
+    public function testAgentRulesDocumentVerifiedBaseBranchWorkflow()
+    {
+        $content = $this->readProjectFile('AGENTS.md');
+
+        $this->assertMatchesPattern('/EvolvePHP 2.*based on.*current `2\.x`|current `2\.x`.*EvolvePHP 2.*based on/is', $content);
+        $this->assertMatchesPattern('/task-specific branch/i', $content);
+        $this->assertMatchesPattern('/verify.*requested base branch.*SHA|requested base branch.*SHA.*verify/is', $content);
+        $this->assertMatchesPattern('/must not infer.*GitHub.*default branch|GitHub.*default branch.*must not infer/is', $content);
+        $this->assertMatchesPattern('/master.*approved legacy maintenance|approved legacy maintenance.*master/is', $content);
+        $this->assertMatchesPattern('/legacy maintenance.*clearly requested|clearly requested.*legacy maintenance/is', $content);
+        $this->assertMatchesPattern('/approved legacy-maintenance task.*start from `master`|start from `master`.*approved legacy-maintenance task/is', $content);
+        $this->assertMatchesPattern('/direct work on `?master`?.*prohibited|prohibited.*direct work on `?master`?/is', $content);
+        $this->assertMatchesPattern('/EvolvePHP 2 changes.*never.*merged into `?master`?|never.*EvolvePHP 2 changes.*`?master`?/is', $content);
+        $this->assertMatchesPattern('/EvolvePHP 1 changes.*not.*mixed into `2\.x`|not.*EvolvePHP 1 changes.*`2\.x`/is', $content);
+    }
+
+    public function testSupportPolicySeparatesDevelopmentAndLegacyMaintenance()
+    {
+        $content = $this->readProjectFile('SUPPORT.md');
+
+        $this->assertMatchesPattern('/EvolvePHP 2 reports.*proposed changes.*target `2\.x`|EvolvePHP 2.*proposed changes.*reports.*`2\.x`/is', $content);
+        $this->assertMatchesPattern('/EvolvePHP 1 legacy maintenance.*`master`.*explicitly approved|explicitly approved.*EvolvePHP 1 legacy maintenance.*`master`/is', $content);
+        $this->assertMatchesPattern('/`master` remains preserved|master.*remains preserved/is', $content);
+        $this->assertMatchesPattern('/new EvolvePHP 2 feature development.*does not target `?master`?|does not target `?master`?.*new EvolvePHP 2 feature development/is', $content);
+        $this->assertMatchesPattern('/EvolvePHP 2.*under development.*not production-ready|not production-ready.*EvolvePHP 2.*under development/is', $content);
+    }
+
+    public function testCanonicalDocumentationKeepsStableCutoverDeferred()
+    {
+        $content = $this->readProjectFile('README.md') . "\n" . $this->readProjectFile('CHANGELOG.md');
+
+        $this->assertMatchesPattern('/`?master`?.*not been renamed or deleted|not been renamed or deleted.*`?master`?/is', $content);
+        $this->assertMatchesPattern('/no `?main`? branch has been created|`?main`? branch has not been created/is', $content);
+        $this->assertMatchesPattern('/no `?1\.x`? branch has been created|`?1\.x`? branch has not been created/is', $content);
+        $this->assertMatchesPattern('/stable-release.*(?:rename|promotion).*deferred|deferred.*stable-release.*(?:rename|promotion)/is', $content);
+        $this->assertMatchesPattern('/Phase 2\.7.*does not replace.*legacy history|legacy history.*not.*replaced.*Phase 2\.7/is', $content);
+    }
+
+    public function testStageAEvidenceBoundaryIsDocumented()
+    {
+        $content = $this->readProjectFile('README.md') . "\n" . $this->readProjectFile('CHANGELOG.md');
+
+        $this->assertMatchesPattern('/Phase 2\.7A.*repository-owned branch-governance policy|repository-owned branch-governance policy.*Phase 2\.7A/is', $content);
+        $this->assertMatchesPattern('/live default-branch.*ruleset.*pending external GitHub evidence|pending external GitHub evidence.*live default-branch.*ruleset/is', $content);
+        $this->assertDoesNotMatchPattern($this->unsupportedDefaultBranchClaimPattern(), $content);
+        $this->assertDoesNotMatchPattern('/branch protection is active|rulesets? (?:is|are) active|required checks (?:are|have been) enforced/i', $content);
+        $this->assertDoesNotMatchPattern('/master (?:was|has been) (?:renamed|deleted|replaced)/i', $content);
+    }
+
+    public function testChangelogRecordsPolicyFoundationWithoutExternalSettingChange()
+    {
+        $content = $this->readProjectFile('CHANGELOG.md');
+
+        $this->assertMatchesPattern('/Phase 2\.7A/i', $content);
+        $this->assertMatchesPattern('/branch-governance policy/i', $content);
+        $this->assertMatchesPattern('/EvolvePHP 2 development on `2\.x`/i', $content);
+        $this->assertMatchesPattern('/EvolvePHP 1 maintenance on `master`/i', $content);
+        $this->assertMatchesPattern('/later default-branch and ruleset transition/i', $content);
+        $this->assertDoesNotMatchPattern($this->unsupportedDefaultBranchClaimPattern(), $content);
+        $this->assertDoesNotMatchPattern('/branch protection is active|rulesets? (?:is|are) active|required checks (?:are|have been) enforced/i', $content);
+    }
+
+    private function unsupportedDefaultBranchClaimPattern()
+    {
+        $branch = '2' . '\.x';
+
+        return '/' . $branch . ' is (?:now |already )?the (?:GitHub )?default branch|default branch (?:is|changed to) `?' . $branch . '/i';
+    }
+
+    private function readProjectFile($path)
+    {
+        $fullPath = $this->root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+        $this->assertFileExists($fullPath, $path . ' should exist before it is read.');
+
+        return file_get_contents($fullPath);
+    }
+
+    private function assertMatchesPattern($pattern, $content)
+    {
+        $this->assertSame(1, preg_match($pattern, $content), 'Failed asserting that content matches ' . $pattern);
+    }
+
+    private function assertDoesNotMatchPattern($pattern, $content)
+    {
+        $this->assertSame(0, preg_match($pattern, $content), 'Failed asserting that content does not match ' . $pattern);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the repository-owned branch-governance policy foundation for EvolvePHP 2 Phase 2.7A.

This PR documents the intended separation between EvolvePHP 2 development on `2.x` and preserved EvolvePHP 1 legacy maintenance on `master`.

The live GitHub default branch remains `master`. Repository rulesets, branch protection and required status checks are intentionally deferred to the Phase 2.7B external-settings gate.

## Changes

- documents `2.x` as the designated EvolvePHP 2 development branch
- preserves `master` as the EvolvePHP 1 legacy line
- prohibits EvolvePHP 2 development from targeting `master`
- requires explicit approval for EvolvePHP 1 legacy maintenance
- requires agents to verify the requested base branch and exact SHA
- keeps implementation work on task-specific branches
- clarifies support and contribution branch ownership
- adds a dedicated repository-governance documentation-policy test
- records the Phase 2.7A policy foundation in the changelog

## Evidence Boundary

This PR does not claim that:

- `2.x` is already the GitHub default branch
- repository rulesets are active
- branch protection is active
- status checks are required
- `master` has been renamed, deleted or replaced
- a `main` or `1.x` branch exists

Those external GitHub changes remain pending Phase 2.7B.

## Local Validation

- governance policy test: 6 tests, 45 assertions
- README consistency: 13 tests, 130 assertions
- RFC consistency: 11 tests, 126 assertions
- Documentation suite: 95 tests, 923 assertions
- Architecture suite: 47 tests, 2,869 assertions
- complete root suite: 142 tests, 3,792 assertions
- PHP 8.4 policy execution: 142 tests, 3,792 assertions
- workspace PHPUnit: 6 tests, 18 assertions
- Deptrac: 0 violations and 0 errors
- PHPStan: no errors
- PHP-CS-Fixer: 0 files fixable
- aggregate workspace quality passed
- Composer manifests valid
- diff check clean

## Phase 2.7B

After this PR is merged and the `2.x` push CI succeeds, Phase 2.7B will separately:

1. configure repository rulesets;
2. verify required status-check identities;
3. change the GitHub default branch from `master` to `2.x`;
4. verify legacy `master` preservation;
5. update repository documentation only after live settings evidence exists.
