### PR TITLE
feat: add configuration foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Runtime foundation
 
+- Added Phase 3.2 configuration foundation with read-only public configuration and validation contracts, a public configuration exception catch boundary, immutable Core array-backed configuration, scalar/null/recursive-array value validation, dot-path lookup with distinct null and missing semantics, deterministic boot-time validator execution, fail-fast validation behavior, terminal failed-kernel instances, and internal Booting/Failed lifecycle states; environment loading, dotenv, container/PSR-11, configuration files, HTTP, module/plugin runtime, console and telemetry remain deferred.
 - Added Phase 3.1 application lifecycle foundation with a narrow public boot/shutdown contract, lifecycle exception catch boundaries, and a minimal Core `ApplicationKernel` state transition implementation; complete kernel behavior, container integration, execution handling, reset behavior, HTTP, module/plugin runtime, console and telemetry remain deferred.
 
 ### Documentation and governance

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,7 +2,7 @@
 
 `packages/` contains the initial EvolvePHP 2 modular-monorepo package set.
 
-The packages define Composer package identities, namespace ownership, dependency direction and the first Phase 3 lifecycle foundation for EvolvePHP 2. Complete runtime implementation is not yet present, and the packages are not yet published.
+The packages define Composer package identities, namespace ownership, dependency direction and the first Phase 3 lifecycle and configuration foundations for EvolvePHP 2. Complete runtime implementation is not yet present for the framework, and the packages are not yet published.
 
 All package manifests require PHP `^8.4`.
 
@@ -10,8 +10,8 @@ All package manifests require PHP `^8.4`.
 
 | Package | Namespace | Responsibility |
 | --- | --- | --- |
-| `evolvephp/contracts` | `Evolve\Contracts\` | Foundational public-contract boundary, including the initial application lifecycle and lifecycle-exception contracts. |
-| `evolvephp/core` | `Evolve\Core\` | Core orchestration boundary, including the initial minimal application lifecycle kernel. |
+| `evolvephp/contracts` | `Evolve\Contracts\` | Foundational public-contract boundary, including the initial application lifecycle, configuration and exception contracts. |
+| `evolvephp/core` | `Evolve\Core\` | Core orchestration boundary, including the initial minimal application lifecycle kernel and array-backed configuration implementation. |
 | `evolvephp/http` | `Evolve\Http\` | HTTP boundary for later request, response, routing and middleware work. |
 | `evolvephp/module` | `Evolve\Module\` | Module SDK boundary for later descriptors and lifecycle contracts. |
 | `evolvephp/plugin` | `Evolve\Plugin\` | Plugin SDK boundary for later descriptors and lifecycle contracts. |
@@ -34,8 +34,10 @@ No optional package families are present here. Insight, Observe, Bridge, Runtime
 
 ## Current Limitations
 
-Contracts and Core now contain the first Phase 3 lifecycle foundation: a narrow application boot/shutdown contract, public lifecycle exception catch boundaries and a minimal Core lifecycle implementation.
+Contracts and Core now contain the first Phase 3 lifecycle and configuration foundations: a narrow application boot/shutdown contract, public lifecycle and configuration exception catch boundaries, read-only configuration lookup contracts, a small validation contract, an immutable Core array-backed configuration implementation and deterministic boot-time validation before readiness.
 
-HTTP, Module, Plugin and Testing runtime source remains intentionally empty in this slice. EvolvePHP 2 does not yet provide HTTP handling, container integration, configuration, execution scopes, reset handling, console behavior, telemetry or production-ready framework runtime behavior.
+Configuration values are application-supplied scalar, null or recursive-array data. Dot-path lookup is supported for associative maps, missing values remain distinct from explicit null values, and validator failure makes that kernel instance terminal; construct a new kernel to retry corrected startup.
+
+HTTP, Module, Plugin and Testing runtime source remains intentionally empty in this slice. EvolvePHP 2 does not yet provide HTTP handling, container or PSR-11 integration, environment or dotenv loading, configuration files, execution scopes, reset handling, module/plugin runtime, console behavior, telemetry or production-ready framework runtime behavior.
 
 The EvolvePHP 2 Composer workspace resolves and validates these local packages. See [../workspace/README.md](../workspace/README.md) for setup, testing, quality commands, lockfile, static-analysis, coding-standard and architecture-boundary policy.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -4,15 +4,20 @@ Foundational public contracts for EvolvePHP 2.
 
 ## Public Contracts
 
-Phase 3.1 introduces the first stable public contract surface:
+Phase 3.2 extends the initial stable public contract surface:
 
 - `Evolve\Contracts\Lifecycle\ApplicationLifecycle`
+- `Evolve\Contracts\Configuration\Configuration`
+- `Evolve\Contracts\Configuration\ConfigurationValidator`
 - `Evolve\Contracts\Exception\EvolveException`
 - `Evolve\Contracts\Exception\LifecycleException`
+- `Evolve\Contracts\Exception\ConfigurationException`
 
-`ApplicationLifecycle` owns only the application boot/shutdown lifecycle. Execution handling, reset behavior, container access, configuration and framework runtime adapters are not part of this contract.
+`ApplicationLifecycle` owns only the application boot/shutdown lifecycle. `Configuration` is read-only to consumers and exposes presence, retrieval, required-value and full-export lookup behavior. `ConfigurationValidator` is a small boot-time validation extension point that receives the read-only configuration and returns `void`.
 
-Consumers should catch public exception contracts such as `LifecycleException` instead of depending on Core concrete exception classes.
+Consumers should catch public exception contracts such as `LifecycleException` and `ConfigurationException` instead of depending on Core concrete exception classes.
+
+Configuration files, environment and dotenv loading, container access, service definitions, execution handling, reset behavior, HTTP handling and framework runtime adapters are not part of these contracts.
 
 ## Package
 

--- a/packages/contracts/src/Configuration/Configuration.php
+++ b/packages/contracts/src/Configuration/Configuration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Contracts\Configuration;
+
+interface Configuration
+{
+    public function has(string $key): bool;
+
+    public function get(string $key, mixed $default = null): mixed;
+
+    public function require(string $key): mixed;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function all(): array;
+}

--- a/packages/contracts/src/Configuration/ConfigurationValidator.php
+++ b/packages/contracts/src/Configuration/ConfigurationValidator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Contracts\Configuration;
+
+interface ConfigurationValidator
+{
+    public function validate(Configuration $configuration): void;
+}

--- a/packages/contracts/src/Exception/ConfigurationException.php
+++ b/packages/contracts/src/Exception/ConfigurationException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Contracts\Exception;
+
+interface ConfigurationException extends EvolveException {}

--- a/packages/contracts/tests/Unit/Configuration/ConfigurationContractTest.php
+++ b/packages/contracts/tests/Unit/Configuration/ConfigurationContractTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Contracts\Tests\Unit\Configuration;
+
+use Evolve\Contracts\Configuration\Configuration;
+use Evolve\Contracts\Configuration\ConfigurationValidator;
+use Evolve\Contracts\Exception\ConfigurationException;
+use Evolve\Contracts\Exception\EvolveException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+final class ConfigurationContractTest extends TestCase
+{
+    public function test_configuration_exposes_read_only_lookup_surface(): void
+    {
+        self::assertTrue(interface_exists(Configuration::class), Configuration::class . ' should exist.');
+
+        $contract = new ReflectionClass(Configuration::class);
+
+        self::assertTrue($contract->isInterface());
+        self::assertSame(['all', 'get', 'has', 'require'], $this->publicMethodNames($contract));
+
+        $this->assertMethodSignature($contract, 'has', ['key' => 'string'], 'bool');
+        $this->assertMethodSignature($contract, 'get', ['key' => 'string', 'default' => 'mixed'], 'mixed');
+        $this->assertMethodSignature($contract, 'require', ['key' => 'string'], 'mixed');
+        $this->assertMethodSignature($contract, 'all', [], 'array');
+
+        $defaultParameter = $contract->getMethod('get')->getParameters()[1];
+
+        self::assertTrue($defaultParameter->isDefaultValueAvailable());
+        self::assertNull($defaultParameter->getDefaultValue());
+
+        foreach (['set', 'replace', 'merge', 'remove', 'clear', 'freeze', 'isFrozen', 'load', 'environment', 'schema'] as $method) {
+            self::assertFalse($contract->hasMethod($method), Configuration::class . ' must not expose ' . $method . '().');
+        }
+    }
+
+    public function test_configuration_validator_exposes_only_validate(): void
+    {
+        self::assertTrue(interface_exists(Configuration::class), Configuration::class . ' should exist.');
+        self::assertTrue(interface_exists(ConfigurationValidator::class), ConfigurationValidator::class . ' should exist.');
+
+        $contract = new ReflectionClass(ConfigurationValidator::class);
+
+        self::assertTrue($contract->isInterface());
+        self::assertSame(['validate'], $this->publicMethodNames($contract));
+        $this->assertMethodSignature($contract, 'validate', ['configuration' => Configuration::class], 'void');
+
+        foreach (['supports', 'rules', 'schema', 'violations', 'errors', 'result', 'priority', 'name'] as $method) {
+            self::assertFalse($contract->hasMethod($method), ConfigurationValidator::class . ' must not expose ' . $method . '().');
+        }
+    }
+
+    public function test_configuration_exception_extends_evolve_exception_without_methods(): void
+    {
+        self::assertTrue(interface_exists(EvolveException::class), EvolveException::class . ' should exist.');
+        self::assertTrue(interface_exists(ConfigurationException::class), ConfigurationException::class . ' should exist.');
+
+        $contract = new ReflectionClass(ConfigurationException::class);
+
+        self::assertTrue($contract->isInterface());
+        self::assertTrue($contract->implementsInterface(EvolveException::class));
+        self::assertSame([], $this->declaredMethodNames($contract));
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param ReflectionClass<T> $contract
+     * @param array<string, string> $expectedParameters
+     */
+    private function assertMethodSignature(ReflectionClass $contract, string $methodName, array $expectedParameters, string $expectedReturnType): void
+    {
+        self::assertTrue($contract->hasMethod($methodName), $contract->getName() . ' should expose ' . $methodName . '().');
+
+        $method = $contract->getMethod($methodName);
+
+        self::assertSame(array_keys($expectedParameters), array_map(
+            static fn(ReflectionParameter $parameter): string => $parameter->getName(),
+            $method->getParameters(),
+        ));
+
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->getType();
+
+            self::assertInstanceOf(ReflectionNamedType::class, $type, $contract->getName() . '::' . $methodName . '() parameter should declare a named type.');
+            self::assertSame($expectedParameters[$parameter->getName()], $type->getName());
+        }
+
+        $returnType = $method->getReturnType();
+
+        self::assertInstanceOf(ReflectionNamedType::class, $returnType, $contract->getName() . '::' . $methodName . '() should declare a named return type.');
+        self::assertSame($expectedReturnType, $returnType->getName());
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param ReflectionClass<T> $contract
+     *
+     * @return list<string>
+     */
+    private function publicMethodNames(ReflectionClass $contract): array
+    {
+        $methodNames = array_map(
+            static fn(ReflectionMethod $method): string => $method->getName(),
+            $contract->getMethods(ReflectionMethod::IS_PUBLIC),
+        );
+
+        sort($methodNames);
+
+        return $methodNames;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param ReflectionClass<T> $contract
+     *
+     * @return list<string>
+     */
+    private function declaredMethodNames(ReflectionClass $contract): array
+    {
+        $methodNames = [];
+
+        foreach ($contract->getMethods() as $method) {
+            if ($method->getDeclaringClass()->getName() === $contract->getName()) {
+                $methodNames[] = $method->getName();
+            }
+        }
+
+        sort($methodNames);
+
+        return $methodNames;
+    }
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,15 +4,20 @@ Application kernel and runtime-neutral orchestration for EvolvePHP 2.
 
 ## Runtime Foundation
 
-Phase 3.1 introduces `Evolve\Core\ApplicationKernel` as the initial lifecycle implementation for the public `ApplicationLifecycle` contract.
+Phase 3.2 extends `Evolve\Core\ApplicationKernel` as the initial lifecycle implementation for the public `ApplicationLifecycle` contract and the first Core host for boot-time configuration validation.
 
-The current lifecycle is intentionally minimal:
+The current lifecycle remains intentionally minimal:
 
 - a new kernel may boot once
+- booting runs configured validators before readiness
 - a booted kernel may shut down once
 - invalid lifecycle transitions fail through the public lifecycle exception catch boundary
+- configuration validation failures fail through the public configuration exception catch boundary
+- a failed kernel instance is terminal; construct a new kernel to retry corrected startup
 
-This slice does not provide container integration, configuration, execution handling, reset participants, HTTP handling, console behavior or telemetry.
+`Evolve\Core\Configuration\ArrayConfiguration` is an immutable array-backed configuration implementation created from already-materialized application values. It stores only scalar, null and recursive-array data, supports dot-path lookup through associative maps, treats missing values and explicit null values differently, and rejects objects, resources, malformed keys, ambiguous array maps and list-index path traversal.
+
+This slice does not provide environment or dotenv loading, configuration files, container or PSR-11 integration, service definitions, execution handling, reset participants, HTTP handling, module/plugin runtime, console behavior or telemetry.
 
 Core continues to depend only on `evolvephp/contracts`. The concrete lifecycle implementation and its internal state enum are not an invitation for consumers to depend on internal lifecycle-state classes.
 

--- a/packages/core/src/ApplicationKernel.php
+++ b/packages/core/src/ApplicationKernel.php
@@ -4,18 +4,64 @@ declare(strict_types=1);
 
 namespace Evolve\Core;
 
+use Evolve\Contracts\Configuration\Configuration;
+use Evolve\Contracts\Configuration\ConfigurationValidator;
+use Evolve\Contracts\Exception\ConfigurationException;
 use Evolve\Contracts\Lifecycle\ApplicationLifecycle;
+use Evolve\Core\Configuration\ArrayConfiguration;
+use Evolve\Core\Exception\ConfigurationValidationFailed;
 use Evolve\Core\Exception\InvalidLifecycleTransition;
 use Evolve\Core\Lifecycle\ApplicationState;
+use InvalidArgumentException;
+use Throwable;
 
 final class ApplicationKernel implements ApplicationLifecycle
 {
     private ApplicationState $state = ApplicationState::Created;
 
+    private Configuration $configuration;
+
+    /**
+     * @var list<ConfigurationValidator>
+     */
+    private array $validators = [];
+
+    /**
+     * @param iterable<mixed> $validators
+     */
+    public function __construct(?Configuration $configuration = null, iterable $validators = [])
+    {
+        $this->configuration = $configuration ?? new ArrayConfiguration();
+
+        foreach ($validators as $validator) {
+            if (! $validator instanceof ConfigurationValidator) {
+                throw new InvalidArgumentException('Application kernel validators must implement ConfigurationValidator.');
+            }
+
+            $this->validators[] = $validator;
+        }
+    }
+
     public function boot(): void
     {
         if ($this->state !== ApplicationState::Created) {
             throw new InvalidLifecycleTransition('Application kernel cannot boot from the current lifecycle state.');
+        }
+
+        $this->state = ApplicationState::Booting;
+
+        try {
+            foreach ($this->validators as $validator) {
+                $validator->validate($this->configuration);
+            }
+        } catch (ConfigurationException $exception) {
+            $this->state = ApplicationState::Failed;
+
+            throw $exception;
+        } catch (Throwable $exception) {
+            $this->state = ApplicationState::Failed;
+
+            throw new ConfigurationValidationFailed('Configuration validation failed.', 0, $exception);
         }
 
         $this->state = ApplicationState::Ready;

--- a/packages/core/src/Configuration/ArrayConfiguration.php
+++ b/packages/core/src/Configuration/ArrayConfiguration.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Configuration;
+
+use Evolve\Contracts\Configuration\Configuration;
+use Evolve\Core\Exception\InvalidConfiguration;
+
+final class ArrayConfiguration implements Configuration
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $values;
+
+    /**
+     * @param array<mixed> $values
+     */
+    public function __construct(array $values = [])
+    {
+        $this->values = self::normalizeRoot($values);
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->find($key)[0];
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        [$found, $value] = $this->find($key);
+
+        if (! $found) {
+            return $default;
+        }
+
+        return $value;
+    }
+
+    public function require(string $key): mixed
+    {
+        [$found, $value] = $this->find($key);
+
+        if (! $found) {
+            throw new InvalidConfiguration('Required configuration value is missing.');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * @param array<mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeRoot(array $values): array
+    {
+        if ($values === []) {
+            return [];
+        }
+
+        if (array_is_list($values)) {
+            throw new InvalidConfiguration('Root configuration must be an associative map.');
+        }
+
+        return self::normalizeAssociativeMap($values);
+    }
+
+    private static function normalizeValue(mixed $value): mixed
+    {
+        if ($value === null || is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            return self::normalizeNestedArray($value);
+        }
+
+        throw new InvalidConfiguration('Configuration values must be scalar, null or recursive arrays.');
+    }
+
+    /**
+     * @param array<mixed> $values
+     *
+     * @return array<mixed>
+     */
+    private static function normalizeNestedArray(array $values): array
+    {
+        if ($values === []) {
+            return [];
+        }
+
+        if (array_is_list($values)) {
+            $normalized = [];
+
+            foreach ($values as $value) {
+                $normalized[] = self::normalizeValue($value);
+            }
+
+            return $normalized;
+        }
+
+        return self::normalizeAssociativeMap($values);
+    }
+
+    /**
+     * @param array<mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeAssociativeMap(array $values): array
+    {
+        $normalized = [];
+
+        foreach ($values as $key => $value) {
+            if (! is_string($key)) {
+                throw new InvalidConfiguration('Associative configuration keys must be strings.');
+            }
+
+            if ($key === '' || str_contains($key, '.')) {
+                throw new InvalidConfiguration('Associative configuration keys must be non-empty and must not contain dots.');
+            }
+
+            $normalized[$key] = self::normalizeValue($value);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array{0: bool, 1: mixed}
+     */
+    private function find(string $key): array
+    {
+        $segments = self::pathSegments($key);
+        $current = $this->values;
+
+        foreach ($segments as $segment) {
+            if (! is_array($current) || array_is_list($current)) {
+                return [false, null];
+            }
+
+            if (! array_key_exists($segment, $current)) {
+                return [false, null];
+            }
+
+            $current = $current[$segment];
+        }
+
+        return [true, $current];
+    }
+
+    /**
+     * @return non-empty-list<string>
+     */
+    private static function pathSegments(string $key): array
+    {
+        if ($key === '' || str_starts_with($key, '.') || str_ends_with($key, '.') || str_contains($key, '..')) {
+            throw new InvalidConfiguration('Configuration path is malformed.');
+        }
+
+        $segments = explode('.', $key);
+
+        foreach ($segments as $segment) {
+            if ($segment === '' || ctype_digit($segment)) {
+                throw new InvalidConfiguration('Configuration path is malformed.');
+            }
+        }
+
+        return $segments;
+    }
+}

--- a/packages/core/src/Exception/ConfigurationValidationFailed.php
+++ b/packages/core/src/Exception/ConfigurationValidationFailed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Exception;
+
+use Evolve\Contracts\Exception\ConfigurationException;
+use RuntimeException;
+
+/**
+ * @internal Core validation implementation detail; catch ConfigurationException instead.
+ */
+final class ConfigurationValidationFailed extends RuntimeException implements ConfigurationException {}

--- a/packages/core/src/Exception/InvalidConfiguration.php
+++ b/packages/core/src/Exception/InvalidConfiguration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Exception;
+
+use Evolve\Contracts\Exception\ConfigurationException;
+use InvalidArgumentException;
+
+/**
+ * @internal Core configuration implementation detail; catch ConfigurationException instead.
+ */
+final class InvalidConfiguration extends InvalidArgumentException implements ConfigurationException {}

--- a/packages/core/src/Lifecycle/ApplicationState.php
+++ b/packages/core/src/Lifecycle/ApplicationState.php
@@ -10,6 +10,8 @@ namespace Evolve\Core\Lifecycle;
 enum ApplicationState
 {
     case Created;
+    case Booting;
     case Ready;
+    case Failed;
     case Stopped;
 }

--- a/packages/core/tests/Unit/ApplicationKernelConfigurationTest.php
+++ b/packages/core/tests/Unit/ApplicationKernelConfigurationTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Unit;
+
+use Closure;
+use Evolve\Contracts\Configuration\Configuration;
+use Evolve\Contracts\Configuration\ConfigurationValidator;
+use Evolve\Contracts\Exception\ConfigurationException;
+use Evolve\Contracts\Exception\LifecycleException;
+use Evolve\Core\ApplicationKernel;
+use Evolve\Core\Configuration\ArrayConfiguration;
+use Evolve\Core\Exception\ConfigurationValidationFailed;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+
+final class ApplicationKernelConfigurationTest extends TestCase
+{
+    public function test_default_kernel_still_boots_and_shuts_down(): void
+    {
+        $kernel = new ApplicationKernel();
+
+        $kernel->boot();
+        $kernel->shutdown();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_valid_supplied_configuration_allows_boot(): void
+    {
+        $kernel = new ApplicationKernel($this->newConfiguration(['app' => 'evolve']));
+
+        $kernel->boot();
+        $kernel->shutdown();
+    }
+
+    public function test_validator_receives_supplied_configuration(): void
+    {
+        $configuration = $this->newConfiguration(['app' => 'evolve']);
+        $received = null;
+
+        $kernel = new ApplicationKernel($configuration, [
+            $this->validator(static function (Configuration $configuration) use (&$received): void {
+                $received = $configuration;
+            }),
+        ]);
+
+        $kernel->boot();
+
+        self::assertSame($configuration, $received);
+    }
+
+    public function test_validators_execute_in_supplied_order(): void
+    {
+        $calls = [];
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function () use (&$calls): void {
+                $calls[] = 'first';
+            }),
+            $this->validator(static function () use (&$calls): void {
+                $calls[] = 'second';
+            }),
+        ]);
+
+        $kernel->boot();
+
+        self::assertSame(['first', 'second'], $calls);
+    }
+
+    public function test_successful_validators_allow_shutdown(): void
+    {
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function (): void {}),
+        ]);
+
+        $kernel->boot();
+        $kernel->shutdown();
+    }
+
+    public function test_configuration_exception_from_validator_prevents_readiness_without_wrapping(): void
+    {
+        $failure = $this->configurationFailure('Invalid supplied configuration.');
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function () use ($failure): void {
+                throw $failure;
+            }),
+        ]);
+
+        try {
+            $kernel->boot();
+            self::fail('Configuration validation should fail.');
+        } catch (Throwable $exception) {
+            self::assertSame($failure, $exception);
+            self::assertNotInstanceOf(ConfigurationValidationFailed::class, $exception);
+        }
+    }
+
+    public function test_unexpected_validator_throwable_is_wrapped_and_preserved(): void
+    {
+        self::assertTrue(class_exists(ConfigurationValidationFailed::class), ConfigurationValidationFailed::class . ' should exist.');
+
+        $failure = new RuntimeException('Unexpected validator failure.');
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function () use ($failure): void {
+                throw $failure;
+            }),
+        ]);
+
+        try {
+            $kernel->boot();
+            self::fail('Unexpected validation throwable should be wrapped.');
+        } catch (Throwable $exception) {
+            self::assertInstanceOf(ConfigurationValidationFailed::class, $exception);
+            self::assertSame($failure, $exception->getPrevious());
+        }
+    }
+
+    public function test_validation_is_fail_fast(): void
+    {
+        $calls = [];
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function () use (&$calls): void {
+                $calls[] = 'first';
+
+                throw new RuntimeException('Stop here.');
+            }),
+            $this->validator(static function () use (&$calls): void {
+                $calls[] = 'second';
+            }),
+        ]);
+
+        try {
+            $kernel->boot();
+            self::fail('Validation should fail fast.');
+        } catch (Throwable) {
+            self::assertSame(['first'], $calls);
+        }
+    }
+
+    public function test_failed_validation_makes_kernel_terminal_for_shutdown_and_boot(): void
+    {
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function (): void {
+                throw new RuntimeException('Invalid.');
+            }),
+        ]);
+
+        $this->ignoreExpectedConfigurationFailure($kernel);
+
+        $this->assertFailsThroughLifecycleException(static function () use ($kernel): void {
+            $kernel->shutdown();
+        });
+
+        $this->assertFailsThroughLifecycleException(static function () use ($kernel): void {
+            $kernel->boot();
+        });
+    }
+
+    public function test_failed_kernel_does_not_rerun_validation(): void
+    {
+        $calls = 0;
+        $kernel = new ApplicationKernel(null, [
+            $this->validator(static function () use (&$calls): void {
+                ++$calls;
+
+                throw new RuntimeException('Invalid.');
+            }),
+        ]);
+
+        $this->ignoreExpectedConfigurationFailure($kernel);
+        $this->assertFailsThroughLifecycleException(static function () use ($kernel): void {
+            $kernel->boot();
+        });
+
+        self::assertSame(1, $calls);
+    }
+
+    public function test_new_kernel_with_corrected_configuration_can_boot_after_prior_failure(): void
+    {
+        $validator = $this->validator(static function (Configuration $configuration): void {
+            if ($configuration->get('feature.enabled') !== true) {
+                throw new RuntimeException('Feature must be enabled.');
+            }
+        });
+
+        $failedKernel = new ApplicationKernel($this->newConfiguration(['feature' => ['enabled' => false]]), [$validator]);
+
+        $this->ignoreExpectedConfigurationFailure($failedKernel);
+
+        $correctedKernel = new ApplicationKernel($this->newConfiguration(['feature' => ['enabled' => true]]), [$validator]);
+
+        $correctedKernel->boot();
+        $correctedKernel->shutdown();
+    }
+
+    public function test_reentrant_boot_during_validation_is_rejected_without_recursing(): void
+    {
+        self::assertTrue(class_exists(ConfigurationValidationFailed::class), ConfigurationValidationFailed::class . ' should exist.');
+
+        $validator = new class implements ConfigurationValidator {
+            public ?ApplicationKernel $kernel = null;
+
+            public int $calls = 0;
+
+            public function validate(Configuration $configuration): void
+            {
+                ++$this->calls;
+
+                if ($this->kernel === null) {
+                    throw new RuntimeException('Kernel reference is missing.');
+                }
+
+                $this->kernel->boot();
+            }
+        };
+        $kernel = new ApplicationKernel(null, [$validator]);
+        $validator->kernel = $kernel;
+
+        try {
+            $kernel->boot();
+            self::fail('Reentrant boot should fail validation.');
+        } catch (Throwable $exception) {
+            self::assertInstanceOf(ConfigurationValidationFailed::class, $exception);
+            self::assertInstanceOf(LifecycleException::class, $exception->getPrevious());
+            self::assertSame(1, $validator->calls);
+        }
+
+        $this->assertFailsThroughLifecycleException(static function () use ($kernel): void {
+            $kernel->boot();
+        });
+    }
+
+    public function test_non_configuration_validator_entries_are_rejected_immediately(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        new ApplicationKernel(null, ['invalid']);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function newConfiguration(array $values): Configuration
+    {
+        self::assertTrue(class_exists(ArrayConfiguration::class), ArrayConfiguration::class . ' should exist.');
+
+        return new ArrayConfiguration($values);
+    }
+
+    /**
+     * @param callable(Configuration): void $callback
+     */
+    private function validator(callable $callback): ConfigurationValidator
+    {
+        self::assertTrue(interface_exists(ConfigurationValidator::class), ConfigurationValidator::class . ' should exist.');
+
+        return new class (Closure::fromCallable($callback)) implements ConfigurationValidator {
+            public function __construct(private Closure $callback) {}
+
+            public function validate(Configuration $configuration): void
+            {
+                ($this->callback)($configuration);
+            }
+        };
+    }
+
+    private function configurationFailure(string $message): ConfigurationException
+    {
+        self::assertTrue(interface_exists(ConfigurationException::class), ConfigurationException::class . ' should exist.');
+
+        return new class ($message) extends RuntimeException implements ConfigurationException {};
+    }
+
+    private function ignoreExpectedConfigurationFailure(ApplicationKernel $kernel): void
+    {
+        try {
+            $kernel->boot();
+            self::fail('Configuration validation should fail.');
+        } catch (Throwable $exception) {
+            self::assertInstanceOf(ConfigurationException::class, $exception);
+        }
+    }
+
+    /**
+     * @param callable(): mixed $operation
+     */
+    private function assertFailsThroughLifecycleException(callable $operation): void
+    {
+        self::assertTrue(interface_exists(LifecycleException::class), LifecycleException::class . ' should exist.');
+
+        try {
+            $operation();
+            self::fail('Invalid lifecycle operation should throw a lifecycle exception.');
+        } catch (Throwable $exception) {
+            self::assertInstanceOf(LifecycleException::class, $exception);
+        }
+    }
+}

--- a/packages/core/tests/Unit/ApplicationKernelTest.php
+++ b/packages/core/tests/Unit/ApplicationKernelTest.php
@@ -22,7 +22,16 @@ final class ApplicationKernelTest extends TestCase
 
         self::assertTrue($kernel->isFinal());
         self::assertTrue($kernel->implementsInterface(ApplicationLifecycle::class));
-        self::assertNull($kernel->getConstructor());
+
+        $constructor = $kernel->getConstructor();
+
+        if ($constructor !== null) {
+            self::assertLessThanOrEqual(2, $constructor->getNumberOfParameters());
+
+            foreach ($constructor->getParameters() as $parameter) {
+                self::assertTrue($parameter->isDefaultValueAvailable(), 'ApplicationKernel constructor parameters must remain optional.');
+            }
+        }
     }
 
     public function test_new_kernel_can_boot_once(): void

--- a/packages/core/tests/Unit/Configuration/ArrayConfigurationTest.php
+++ b/packages/core/tests/Unit/Configuration/ArrayConfigurationTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Unit\Configuration;
+
+use Evolve\Contracts\Configuration\Configuration;
+use Evolve\Contracts\Exception\ConfigurationException;
+use Evolve\Core\Configuration\ArrayConfiguration;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Throwable;
+
+final class ArrayConfigurationTest extends TestCase
+{
+    public function test_array_configuration_is_final_read_only_configuration(): void
+    {
+        self::assertTrue(class_exists(ArrayConfiguration::class), ArrayConfiguration::class . ' should exist.');
+        self::assertTrue(interface_exists(Configuration::class), Configuration::class . ' should exist.');
+
+        $configuration = new ReflectionClass(ArrayConfiguration::class);
+
+        self::assertTrue($configuration->isFinal());
+        self::assertTrue($configuration->implementsInterface(Configuration::class));
+
+        foreach (['set', 'replace', 'merge', 'remove', 'clear', 'freeze', 'isFrozen', 'load', 'environment', 'schema'] as $method) {
+            self::assertFalse($configuration->hasMethod($method), ArrayConfiguration::class . ' must not expose ' . $method . '().');
+        }
+    }
+
+    public function test_empty_configuration_is_valid(): void
+    {
+        $configuration = $this->newConfiguration();
+
+        self::assertSame([], $configuration->all());
+        self::assertFalse($configuration->has('missing'));
+        self::assertSame('fallback', $configuration->get('missing', 'fallback'));
+    }
+
+    public function test_top_level_and_nested_dot_paths_are_readable(): void
+    {
+        $configuration = $this->newConfiguration([
+            'app' => 'evolve',
+            'database' => [
+                'host' => 'localhost',
+                'options' => [
+                    'timeout' => 30,
+                ],
+            ],
+            'mail' => [
+                'transport' => 'smtp',
+            ],
+        ]);
+
+        self::assertTrue($configuration->has('app'));
+        self::assertTrue($configuration->has('database.host'));
+        self::assertSame('evolve', $configuration->get('app'));
+        self::assertSame('localhost', $configuration->get('database.host'));
+        self::assertSame(30, $configuration->require('database.options.timeout'));
+        self::assertSame('smtp', $configuration->require('mail.transport'));
+    }
+
+    public function test_null_is_present_and_missing_values_use_default_or_exception(): void
+    {
+        $configuration = $this->newConfiguration([
+            'feature' => [
+                'value' => null,
+            ],
+        ]);
+
+        self::assertTrue($configuration->has('feature.value'));
+        self::assertFalse($configuration->has('missing.value'));
+        self::assertNull($configuration->get('feature.value', 'fallback'));
+        self::assertSame('fallback', $configuration->get('missing.value', 'fallback'));
+        self::assertNull($configuration->require('feature.value'));
+
+        $this->assertFailsThroughConfigurationException(static function () use ($configuration): void {
+            $configuration->require('missing.value');
+        });
+    }
+
+    public function test_all_returns_complete_data_without_mutation_leakage(): void
+    {
+        $configuration = $this->newConfiguration([
+            'database' => [
+                'host' => 'localhost',
+            ],
+        ]);
+
+        $exported = $configuration->all();
+        $exported['database']['host'] = 'changed';
+
+        self::assertSame(['database' => ['host' => 'localhost']], $configuration->all());
+        self::assertSame('localhost', $configuration->get('database.host'));
+    }
+
+    public function test_nested_associative_maps_and_lists_remain_valid_data(): void
+    {
+        $configuration = $this->newConfiguration([
+            'database' => [
+                'options' => [
+                    'timeout' => 30,
+                ],
+            ],
+            'servers' => [
+                [
+                    'host' => 'one',
+                ],
+                [
+                    'host' => 'two',
+                ],
+            ],
+            'callable_like_data' => [
+                'strlen',
+                ['ExampleClass', 'method'],
+            ],
+        ]);
+
+        self::assertSame(['timeout' => 30], $configuration->require('database.options'));
+        self::assertSame([['host' => 'one'], ['host' => 'two']], $configuration->require('servers'));
+        self::assertSame(['strlen', ['ExampleClass', 'method']], $configuration->require('callable_like_data'));
+    }
+
+    public function test_object_values_are_rejected(): void
+    {
+        $this->assertFailsThroughConfigurationException(static function (): void {
+            new ArrayConfiguration(['invalid' => new \stdClass()]);
+        });
+    }
+
+    public function test_resource_values_are_rejected(): void
+    {
+        $resource = fopen('php://memory', 'r');
+
+        self::assertIsResource($resource);
+
+        try {
+            $this->assertFailsThroughConfigurationException(static function () use ($resource): void {
+                new ArrayConfiguration(['invalid' => $resource]);
+            });
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function test_non_empty_root_list_is_rejected(): void
+    {
+        $this->assertFailsThroughConfigurationException(static function (): void {
+            new ArrayConfiguration(['one', 'two']);
+        });
+    }
+
+    public function test_mixed_associative_and_integer_key_maps_are_rejected(): void
+    {
+        $this->assertFailsThroughConfigurationException(static function (): void {
+            new ArrayConfiguration(['valid' => true, 0 => 'ambiguous']);
+        });
+    }
+
+    public function test_empty_associative_keys_are_rejected(): void
+    {
+        $this->assertFailsThroughConfigurationException(static function (): void {
+            new ArrayConfiguration(['' => 'invalid']);
+        });
+    }
+
+    public function test_associative_keys_containing_dots_are_rejected(): void
+    {
+        $this->assertFailsThroughConfigurationException(static function (): void {
+            new ArrayConfiguration(['database.host' => 'invalid']);
+        });
+    }
+
+    public function test_malformed_lookup_paths_are_rejected(): void
+    {
+        $configuration = $this->newConfiguration(['database' => ['host' => 'localhost']]);
+
+        foreach (['', '.database', 'database.', 'database..host', '0', 'database.0'] as $path) {
+            $this->assertFailsThroughConfigurationException(static function () use ($configuration, $path): void {
+                $configuration->has($path);
+            });
+
+            $this->assertFailsThroughConfigurationException(static function () use ($configuration, $path): void {
+                $configuration->get($path);
+            });
+
+            $this->assertFailsThroughConfigurationException(static function () use ($configuration, $path): void {
+                $configuration->require($path);
+            });
+        }
+    }
+
+    public function test_list_indexes_are_not_public_dot_path_segments(): void
+    {
+        $configuration = $this->newConfiguration([
+            'servers' => [
+                ['host' => 'one'],
+            ],
+        ]);
+
+        $this->assertFailsThroughConfigurationException(static function () use ($configuration): void {
+            $configuration->get('servers.0.host');
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function newConfiguration(array $values = []): ArrayConfiguration
+    {
+        self::assertTrue(class_exists(ArrayConfiguration::class), ArrayConfiguration::class . ' should exist.');
+
+        return new ArrayConfiguration($values);
+    }
+
+    /**
+     * @param callable(): mixed $operation
+     */
+    private function assertFailsThroughConfigurationException(callable $operation): void
+    {
+        self::assertTrue(interface_exists(ConfigurationException::class), ConfigurationException::class . ' should exist.');
+
+        try {
+            $operation();
+            self::fail('Invalid configuration operation should throw a configuration exception.');
+        } catch (Throwable $exception) {
+            self::assertInstanceOf(ConfigurationException::class, $exception);
+        }
+    }
+}

--- a/tests/Architecture/EvolvePhp2PackageSkeletonTest.php
+++ b/tests/Architecture/EvolvePhp2PackageSkeletonTest.php
@@ -114,9 +114,9 @@ final class EvolvePhp2PackageSkeletonTest extends TestCase
         }
     }
 
-    public function testPackageSourcesMatchPhase31RuntimeInventory(): void
+    public function testPackageSourcesMatchPhase32RuntimeInventory(): void
     {
-        foreach ($this->phase31SourceInventories() as $sourceDirectory => $expectedFiles) {
+        foreach ($this->phase32SourceInventories() as $sourceDirectory => $expectedFiles) {
             $fullSourceDirectory = $this->projectPath($sourceDirectory);
 
             $this->assertTrue(is_dir($fullSourceDirectory), $sourceDirectory . ' should exist before source files are inspected.');
@@ -124,7 +124,7 @@ final class EvolvePhp2PackageSkeletonTest extends TestCase
             $this->assertSame(
                 $expectedFiles,
                 $this->phpFilesUnderSource($fullSourceDirectory),
-                $sourceDirectory . ' should contain exactly the approved Phase 3.1 PHP source inventory.'
+                $sourceDirectory . ' should contain exactly the approved Phase 3.2 PHP source inventory.'
             );
         }
 
@@ -145,7 +145,7 @@ final class EvolvePhp2PackageSkeletonTest extends TestCase
 
         $this->assertMatchesPattern('/# EvolvePHP 2 Packages/i', $content);
         $this->assertMatchesPattern('/skeleton|foundation|boundar/i', $content);
-        $this->assertMatchesPattern('/runtime (?:framework )?implementation is not yet present/i', $content);
+        $this->assertMatchesPattern('/complete runtime (?:framework )?implementation is not yet present/i', $content);
         $this->assertMatchesPattern('/packages.*not yet published|not yet published.*packages/i', $content);
         $this->assertMatchesPattern('/PHP `?\^8\.4`?/i', $content);
         $this->assertMatchesPattern('/arrows.*dependency direction.*not lifecycle invocation/i', $content);
@@ -235,16 +235,22 @@ final class EvolvePhp2PackageSkeletonTest extends TestCase
         );
     }
 
-    private function phase31SourceInventories()
+    private function phase32SourceInventories()
     {
         return array(
             'packages/contracts/src' => array(
+                'Configuration/Configuration.php',
+                'Configuration/ConfigurationValidator.php',
+                'Exception/ConfigurationException.php',
                 'Exception/EvolveException.php',
                 'Exception/LifecycleException.php',
                 'Lifecycle/ApplicationLifecycle.php',
             ),
             'packages/core/src' => array(
                 'ApplicationKernel.php',
+                'Configuration/ArrayConfiguration.php',
+                'Exception/ConfigurationValidationFailed.php',
+                'Exception/InvalidConfiguration.php',
                 'Exception/InvalidLifecycleTransition.php',
                 'Lifecycle/ApplicationState.php',
             ),


### PR DESCRIPTION
## Summary

Implements EvolvePHP 2 Phase 3.2 — Configuration Foundation and Boot-Time Validation.

This adds immutable application configuration and deterministic validation before the application kernel reaches Ready state.

## Public Contracts

Adds:

- `Evolve\Contracts\Configuration\Configuration`
- `Evolve\Contracts\Configuration\ConfigurationValidator`
- `Evolve\Contracts\Exception\ConfigurationException`

Configuration is read-only and exposes:

- `has(string $key): bool`
- `get(string $key, mixed $default = null): mixed`
- `require(string $key): mixed`
- `all(): array`

## Core Configuration

Adds:

- `Evolve\Core\Configuration\ArrayConfiguration`
- `Evolve\Core\Exception\InvalidConfiguration`
- `Evolve\Core\Exception\ConfigurationValidationFailed`

Supported values are scalar, null, and recursive arrays.

Configuration is immutable from construction and supports deterministic associative dot-path lookup.

Missing values and explicitly present null values remain distinct.

## Kernel Validation

`ApplicationKernel` now accepts configuration and validators through constructor composition while preserving:

`ApplicationLifecycle::boot(): void`

Lifecycle becomes:

Created -> Booting -> Ready -> Stopped

Validation failure:

Booting -> Failed

`Failed` is terminal for that kernel instance.

Validators:

- execute in supplied order
- run before Ready
- are fail-fast
- receive read-only configuration
- require no container/service resolution

Validator `ConfigurationException` failures propagate through the public configuration catch boundary.

Unexpected validator throwables are wrapped in `ConfigurationValidationFailed` with the original throwable preserved.

## Architecture Boundaries

Phase 3.2 intentionally does not implement:

- PSR-11 or container integration
- service definitions
- environment/dotenv loading
- configuration file discovery
- HTTP
- modules/plugins runtime
- console
- telemetry
- Insight
- OpenTelemetry
- Bridge

No third-party dependencies were added.

## Validation

- Contracts: 7 tests, 88 assertions
- Core: 36 tests, 163 assertions
- Workspace: 47 tests, 263 assertions
- Architecture: 48 tests, 3462 assertions
- Documentation: 128 tests, 1685 assertions
- Combined root policy: 176 tests, 5147 assertions
- PHPStan: no errors
- PHP-CS-Fixer: 0 fixable files
- Deptrac: 0 violations, errors or uncovered dependencies
- aggregate quality: passed
- supply-chain: passed
- Composer strict validation: passed
- release metadata validation: passed

## Package Split Validation

Committed-ref validation passed against:

447eb11fa0cc628bdd3cc2f75d0721cc6f713f84

Contracts:
- split: ceb6ec8931c431f42a0b7dc82c51db19467fe2c7
- 12 files
- 5 history commits

Core:
- split: 8d1e39d59171684d2d1c7b1928c917cb64d804de
- 13 files
- 5 history commits

Module, Plugin, HTTP and Testing remain unchanged from Phase 3.1.

All six package splits passed:

- repeated split determinism
- tree equality
- inventory equality
- strict Composer validation

## Scope

Exactly 17 files:

- 9 added
- 8 modified
- 0 deleted

No Composer manifest, lockfile, CI workflow or repository-setting changes.