### PR TITLE
docs: correct core lifecycle chronology

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@ Application kernel and runtime-neutral orchestration for EvolvePHP 2.
 
 ## Runtime Foundation
 
-Phase 3.5 extends `Evolve\Core\ApplicationKernel` as the initial lifecycle implementation for the public `ApplicationLifecycle` contract, the first Core host for boot-time configuration validation and the integration point that freezes an optional service registry before readiness.
+Phase 3.1 introduced `Evolve\Core\ApplicationKernel` as the initial lifecycle implementation for the public `ApplicationLifecycle` contract. Phases 3.2 through 3.5 extended the runtime foundation with boot-time configuration validation, service-registry freezing, explicit execution scopes and, in Phase 3.5, runtime-neutral execution orchestration.
 
 The current lifecycle remains intentionally minimal:
 

--- a/tests/Documentation/EvolvePhp2ReadmeAndMetadataConsistencyTest.php
+++ b/tests/Documentation/EvolvePhp2ReadmeAndMetadataConsistencyTest.php
@@ -121,6 +121,26 @@ final class EvolvePhp2ReadmeAndMetadataConsistencyTest extends TestCase
         $this->assertDoesNotMatchPattern('/Before Phase 2\.3/i', $content);
     }
 
+    public function testCoreReadmeDocumentsCorrectPhase3LifecycleChronology(): void
+    {
+        $content = $this->readProjectFile('packages/core/README.md');
+
+        $this->assertDoesNotMatchPattern(
+            '/Phase 3\.5\s+extends\s+`Evolve\\\\Core\\\\ApplicationKernel`\s+as the initial lifecycle implementation/i',
+            $content,
+        );
+
+        $this->assertMatchesPattern(
+            '/Phase 3\.1 introduced `Evolve\\\\Core\\\\ApplicationKernel` as the initial lifecycle implementation/i',
+            $content,
+        );
+
+        $this->assertMatchesPattern(
+            '/in Phase 3\.5, runtime-neutral execution orchestration/i',
+            $content,
+        );
+    }
+
     public function testDevelopmentGuideOwnsCompleteArchitectureMatrix(): void
     {
         $content = $this->readProjectFile('DEVELOPMENT.md');


### PR DESCRIPTION
## Summary
- correct the Core README chronology so `ApplicationKernel` is attributed to Phase 3.1
- keep Phase 3.5 correctly tied to runtime-neutral execution orchestration
- add focused documentation-policy coverage to prevent regression

## Validation
- focused documentation policy: 14 tests / 170 assertions
- Architecture + Documentation: 187 tests / 6087 assertions
- full quality: 296 tests / 1242 assertions, Deptrac clean, PHPStan clean, PHP-CS-Fixer clean
- supply-chain validation passed
- deterministic package splits passed; only Core split changed
- offline prerelease consumer A-H matrix passed

Exact scope: 2 files. No production PHP, dependency, manifest, RFC, or Phase 5.3A changes.