### PR TITLE
Add Doctor console command adapter

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -126,3 +126,40 @@ command, `bin/evolve`, JSON output, Composer compatibility diagnosis,
 environment inspection, route inspection, writable-path validation, Bridge
 validation, persistent-worker certification, Evolve Audit integration, or
 automatic remediation.
+## Evolve Doctor Console Adapter
+
+Core provides `Evolve\Core\Doctor\Console\DoctorCommand`, a runtime-neutral
+adapter from an explicitly configured `DoctorRunner` to the existing Core
+`Command` abstraction. The command name is `doctor` and its description is
+`Run configured Evolve Doctor diagnostic checks.`
+
+The adapter accepts no arguments or options. Empty input runs the configured
+Doctor runner and renders findings deterministically in report order as:
+
+```text
+[STATUS] identifier: message
+```
+
+When a finding includes remediation, the command emits a following normal output
+line:
+
+```text
+Remediation: <remediation>
+```
+
+PASS, WARNING, and FAIL findings are diagnostic output written through the
+normal command output channel. FAIL findings produce command exit status `1`.
+Warnings alone remain successful and produce exit status `0`. Unsupported
+arguments or options produce exit status `2` with the error
+`The doctor command does not accept arguments or options.`
+
+Malformed Doctor definitions and programming failures remain throwables. When
+the command is dispatched through Core's generic `CommandRunner`, execution
+continues to use the existing `ExecutionOrchestrator` lifecycle for CLI command
+failures.
+
+Current limitations: this phase does not provide `bin/evolve`, argv parsing,
+runtime stdout/stderr stream implementations, TTY support, ANSI formatting,
+prompts, command help UI, JSON Doctor output, Composer compatibility checks,
+project discovery, route inspection, environment inspection, writable-path
+inspection, create-project, or generators.

--- a/packages/core/src/Doctor/Console/DoctorCommand.php
+++ b/packages/core/src/Doctor/Console/DoctorCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Doctor\Console;
+
+use Evolve\Core\Console\Command;
+use Evolve\Core\Console\CommandInput;
+use Evolve\Core\Console\CommandOutput;
+use Evolve\Core\Console\CommandResult;
+use Evolve\Core\Doctor\DoctorFinding;
+use Evolve\Core\Doctor\DoctorRunner;
+
+final readonly class DoctorCommand implements Command
+{
+    public function __construct(
+        private DoctorRunner $doctor,
+    ) {}
+
+    public function name(): string
+    {
+        return 'doctor';
+    }
+
+    public function description(): string
+    {
+        return 'Run configured Evolve Doctor diagnostic checks.';
+    }
+
+    public function execute(CommandInput $input, CommandOutput $output): CommandResult
+    {
+        if ($input->tokens() !== []) {
+            $output->writeError('The doctor command does not accept arguments or options.');
+
+            return new CommandResult(2);
+        }
+
+        $report = $this->doctor->run();
+
+        foreach ($report->findings() as $finding) {
+            $this->writeFinding($finding, $output);
+        }
+
+        return new CommandResult($report->successful() ? 0 : 1);
+    }
+
+    private function writeFinding(DoctorFinding $finding, CommandOutput $output): void
+    {
+        $output->write(sprintf(
+            '[%s] %s: %s',
+            strtoupper($finding->status()->value),
+            $finding->identifier(),
+            $finding->message(),
+        ));
+
+        if ($finding->remediation() !== null) {
+            $output->write(sprintf('Remediation: %s', $finding->remediation()));
+        }
+    }
+}

--- a/packages/core/tests/Unit/Doctor/Console/DoctorCommandTest.php
+++ b/packages/core/tests/Unit/Doctor/Console/DoctorCommandTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Unit\Doctor\Console;
+
+use Closure;
+use Evolve\Core\Console\CommandInput;
+use Evolve\Core\Console\CommandOutput;
+use Evolve\Core\Doctor\Console\DoctorCommand;
+use Evolve\Core\Doctor\DoctorCheck;
+use Evolve\Core\Doctor\DoctorFinding;
+use Evolve\Core\Doctor\DoctorRunner;
+use Evolve\Core\Doctor\DoctorStatus;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+final class DoctorCommandTest extends TestCase
+{
+    public function testCommandNameIsDoctor(): void
+    {
+        self::assertSame('doctor', $this->command([])->name());
+    }
+
+    public function testCommandDescriptionIsStable(): void
+    {
+        self::assertSame(
+            'Run configured Evolve Doctor diagnostic checks.',
+            $this->command([])->description(),
+        );
+    }
+
+    public function testPassFindingRendersNormalOutputAndReturnsSuccess(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $result = $this->command([
+            $this->check('runtime.php.version', DoctorStatus::Pass, 'PHP version is supported.'),
+        ])->execute(new CommandInput([]), $output);
+
+        self::assertSame(0, $result->exitCode());
+        self::assertSame(['[PASS] runtime.php.version: PHP version is supported.'], $output->lines());
+        self::assertSame([], $output->errorLines());
+    }
+
+    public function testWarningFindingRendersNormalOutputAndReturnsSuccess(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $result = $this->command([
+            $this->check('runtime.cache', DoctorStatus::Warning, 'Cache directory could not be verified.'),
+        ])->execute(new CommandInput([]), $output);
+
+        self::assertSame(0, $result->exitCode());
+        self::assertSame(['[WARNING] runtime.cache: Cache directory could not be verified.'], $output->lines());
+        self::assertSame([], $output->errorLines());
+    }
+
+    public function testFailFindingRendersNormalOutputAndReturnsFailureStatus(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $result = $this->command([
+            $this->check('runtime.php.extensions', DoctorStatus::Fail, 'Missing required PHP extension: mbstring.'),
+        ])->execute(new CommandInput([]), $output);
+
+        self::assertSame(1, $result->exitCode());
+        self::assertSame(['[FAIL] runtime.php.extensions: Missing required PHP extension: mbstring.'], $output->lines());
+        self::assertSame([], $output->errorLines());
+    }
+
+    public function testFindingWithRemediationEmitsFindingThenRemediationAsNormalOutput(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $this->command([
+            $this->check(
+                'runtime.php.extensions',
+                DoctorStatus::Fail,
+                'Missing required PHP extension: mbstring.',
+                'Install or enable the missing PHP extension: mbstring.',
+            ),
+        ])->execute(new CommandInput([]), $output);
+
+        self::assertSame([
+            '[FAIL] runtime.php.extensions: Missing required PHP extension: mbstring.',
+            'Remediation: Install or enable the missing PHP extension: mbstring.',
+        ], $output->lines());
+        self::assertSame([], $output->errorLines());
+    }
+
+    public function testFindingWithoutRemediationEmitsNoRemediationLine(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $this->command([
+            $this->check('runtime.php.version', DoctorStatus::Pass, 'PHP version is supported.'),
+        ])->execute(new CommandInput([]), $output);
+
+        self::assertSame(['[PASS] runtime.php.version: PHP version is supported.'], $output->lines());
+    }
+
+    public function testMultipleFindingsPreserveReportOrderWithoutGrouping(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $this->command([
+            $this->check('runtime.php.version', DoctorStatus::Pass, 'PHP version is supported.'),
+            $this->check('runtime.cache', DoctorStatus::Warning, 'Cache directory could not be verified.'),
+            $this->check('runtime.php.extensions', DoctorStatus::Fail, 'Missing required PHP extension: mbstring.'),
+        ])->execute(new CommandInput([]), $output);
+
+        self::assertSame([
+            '[PASS] runtime.php.version: PHP version is supported.',
+            '[WARNING] runtime.cache: Cache directory could not be verified.',
+            '[FAIL] runtime.php.extensions: Missing required PHP extension: mbstring.',
+        ], $output->lines());
+    }
+
+    public function testUnsupportedInputTokenReturnsUsageErrorWithoutNormalOutput(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $result = $this->command([
+            $this->check('runtime.php.version', DoctorStatus::Pass, 'PHP version is supported.'),
+        ])->execute(new CommandInput(['--json']), $output);
+
+        self::assertSame(2, $result->exitCode());
+        self::assertSame([], $output->lines());
+        self::assertSame(['The doctor command does not accept arguments or options.'], $output->errorLines());
+    }
+
+    public function testMultipleUnsupportedInputTokensReturnUsageErrorWithoutNormalOutput(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $result = $this->command([
+            $this->check('runtime.php.version', DoctorStatus::Pass, 'PHP version is supported.'),
+        ])->execute(new CommandInput(['--json', '--verbose']), $output);
+
+        self::assertSame(2, $result->exitCode());
+        self::assertSame([], $output->lines());
+        self::assertSame(['The doctor command does not accept arguments or options.'], $output->errorLines());
+    }
+
+    public function testUnsupportedInputPreventsDoctorChecksFromRunning(): void
+    {
+        $ran = false;
+        $output = new RecordingCommandOutput();
+
+        $this->command([
+            $this->check(
+                'runtime.php.version',
+                DoctorStatus::Pass,
+                'PHP version is supported.',
+                null,
+                static function (string $_identifier) use (&$ran): void {
+                    $ran = true;
+                },
+            ),
+        ])->execute(new CommandInput(['--json']), $output);
+
+        self::assertFalse($ran);
+    }
+
+    public function testEmptyDoctorRunnerProducesNoOutputAndReturnsSuccess(): void
+    {
+        $output = new RecordingCommandOutput();
+
+        $result = $this->command([])->execute(new CommandInput([]), $output);
+
+        self::assertSame(0, $result->exitCode());
+        self::assertSame([], $output->lines());
+        self::assertSame([], $output->errorLines());
+    }
+
+    public function testMalformedDoctorExecutionFailurePropagates(): void
+    {
+        $this->expectException(LogicException::class);
+
+        $this->command([
+            new class implements DoctorCheck {
+                public function identifier(): string
+                {
+                    return 'runtime.php.version';
+                }
+
+                public function run(): DoctorFinding
+                {
+                    return new DoctorFinding(
+                        'runtime.php.extensions',
+                        DoctorStatus::Pass,
+                        'PHP extensions are loaded.',
+                    );
+                }
+            },
+        ])->execute(new CommandInput([]), new RecordingCommandOutput());
+    }
+
+    /**
+     * @param iterable<DoctorCheck> $checks
+     */
+    private function command(iterable $checks): DoctorCommand
+    {
+        return new DoctorCommand(new DoctorRunner($checks));
+    }
+
+    /**
+     * @param (Closure(string): void)|null $onRun
+     */
+    private function check(
+        string $identifier,
+        DoctorStatus $status,
+        string $message,
+        ?string $remediation = null,
+        ?Closure $onRun = null,
+    ): DoctorCheck {
+        return new class ($identifier, $status, $message, $remediation, $onRun) implements DoctorCheck {
+            public function __construct(
+                private readonly string $identifier,
+                private readonly DoctorStatus $status,
+                private readonly string $message,
+                private readonly ?string $remediation,
+                private readonly ?Closure $onRun,
+            ) {}
+
+            public function identifier(): string
+            {
+                return $this->identifier;
+            }
+
+            public function run(): DoctorFinding
+            {
+                if ($this->onRun !== null) {
+                    ($this->onRun)($this->identifier);
+                }
+
+                return new DoctorFinding(
+                    $this->identifier,
+                    $this->status,
+                    $this->message,
+                    $this->remediation,
+                );
+            }
+        };
+    }
+}
+
+final class RecordingCommandOutput implements CommandOutput
+{
+    /** @var list<string> */
+    private array $lines = [];
+
+    /** @var list<string> */
+    private array $errorLines = [];
+
+    public function write(string $message): void
+    {
+        $this->lines[] = $message;
+    }
+
+    public function writeError(string $message): void
+    {
+        $this->errorLines[] = $message;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function lines(): array
+    {
+        return $this->lines;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function errorLines(): array
+    {
+        return $this->errorLines;
+    }
+}

--- a/tests/Architecture/EvolvePhp2PackageSkeletonTest.php
+++ b/tests/Architecture/EvolvePhp2PackageSkeletonTest.php
@@ -761,6 +761,7 @@ final class EvolvePhp2PackageSkeletonTest extends TestCase
                 'Container/ServiceDefinition.php',
                 'Container/ServiceLifetime.php',
             'Container/ServiceRegistry.php',
+            'Doctor/Console/DoctorCommand.php',
             'Doctor/DoctorCheck.php',
             'Doctor/DoctorFinding.php',
             'Doctor/DoctorReport.php',


### PR DESCRIPTION
## Summary

Adds a runtime-neutral `doctor` command adapter that connects the existing Doctor diagnostics to Core's console command abstraction.

## Changes

- adds `DoctorCommand` backed by an injected `DoctorRunner`
- renders PASS, WARNING, and FAIL findings in deterministic report order
- emits remediation immediately after its finding when available
- returns exit code 0 for successful reports, 1 for diagnostic failures, and 2 for unsupported arguments
- keeps diagnostic failures on normal command output rather than the error channel
- preserves programming and malformed-definition failures as throwables
- documents the console adapter and its current limitations
- updates the Core source inventory and adds focused command coverage

## Validation

- 548 tests / 2064 assertions
- architecture suite: 63 tests / 5575 assertions
- documentation suite: 130 tests / 2124 assertions
- dependency analysis: 0 violations
- PHP CS Fixer: 186 files checked, 0 fixable
- release package validation passed
- package split validation passed
- prerelease consumer validation passed
- security audit and licence policy passed

## Package split

Core:
`e0eb08cf23fa393050210954cbd050963d582f95`

## Scope

4 files changed, 380 insertions.

No shell executable, argv parser, JSON output, Composer probing, environment inspection, route inspection, writable-path inspection, dependency changes, or package-manifest changes are included.