### PR TITLE
Add Evolve CLI doctor entrypoint

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -38,7 +38,7 @@
             "dist": {
                 "type": "path",
                 "url": "packages/core",
-                "reference": "6d6004c21b5cf7c44aed07ebb2da538e8ffb0c48"
+                "reference": "75ecd3a61fcdfa62cfa168fbfce965709f455973"
             },
             "require": {
                 "evolvephp/contracts": "^2.0",
@@ -48,6 +48,9 @@
             "provide": {
                 "psr/container-implementation": "1.0.0"
             },
+            "bin": [
+                "bin/evolve"
+            ],
             "type": "library",
             "autoload": {
                 "psr-4": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -158,8 +158,37 @@ the command is dispatched through Core's generic `CommandRunner`, execution
 continues to use the existing `ExecutionOrchestrator` lifecycle for CLI command
 failures.
 
-Current limitations: this phase does not provide `bin/evolve`, argv parsing,
-runtime stdout/stderr stream implementations, TTY support, ANSI formatting,
-prompts, command help UI, JSON Doctor output, Composer compatibility checks,
-project discovery, route inspection, environment inspection, writable-path
-inspection, create-project, or generators.
+Current Doctor command adapter limitations: this layer does not provide argv
+parsing, TTY support, ANSI formatting, prompts, command help UI, JSON Doctor
+output, Composer compatibility checks, project discovery, route inspection,
+environment inspection, writable-path inspection, create-project, or generators.
+## Evolve CLI Entrypoint
+
+Core exposes a Composer binary for the first shell-facing Evolve CLI entrypoint:
+
+```text
+vendor/bin/evolve doctor
+```
+
+The package-owned `bin/evolve` executable is a thin composition root around the
+existing Core console abstractions. It wires `CliApplication` to `CommandRunner`,
+registers the existing `DoctorCommand`, and configures the default shell Doctor
+runner with the PHP version check.
+
+Current shell behavior:
+
+- stdout is used for normal command and Doctor diagnostic output.
+- stderr is used for shell and usage errors.
+- exit `0` means the Doctor report was successful.
+- exit `1` means Doctor reported at least one diagnostic failure.
+- exit `2` means CLI usage failed, such as a missing command or unsupported
+  Doctor argument.
+- PASS, WARNING, and FAIL rendering remains owned by `DoctorCommand`.
+- Caller-configured PHP extension checks remain available programmatically but
+  are not auto-discovered by the shell entrypoint yet.
+
+Current limitations: there is no option parser, `--help` or help framework,
+JSON output, command listing or completion, Composer or project inspection,
+automatic required-extension discovery, route inspection, environment
+inspection, writable-path inspection, create-project support, generators,
+Bridge or Audit integration, or interactive, TTY, or ANSI behavior.

--- a/packages/core/bin/evolve
+++ b/packages/core/bin/evolve
@@ -1,0 +1,59 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Evolve\Core\Console\CommandRegistry;
+use Evolve\Core\Console\CommandRunner;
+use Evolve\Core\Console\Runtime\CliApplication;
+use Evolve\Core\Console\Runtime\StreamCommandOutput;
+use Evolve\Core\Container\ServiceRegistry;
+use Evolve\Core\Doctor\Console\DoctorCommand;
+use Evolve\Core\Doctor\DoctorRunner as EvolveDoctorRunner;
+use Evolve\Core\Doctor\Runtime\PhpVersionCheck;
+use Evolve\Core\Execution\ExecutionOrchestrator;
+
+$composerAutoloadPath = $_composer_autoload_path ?? null;
+
+$autoload = static function () use ($composerAutoloadPath): string {
+    if (
+        is_string($composerAutoloadPath)
+        && is_file($composerAutoloadPath)
+    ) {
+        return $composerAutoloadPath;
+    }
+
+    $candidates = [
+        __DIR__ . '/../vendor/autoload.php',
+        __DIR__ . '/../../../vendor/autoload.php',
+        __DIR__ . '/../../../../vendor/autoload.php',
+    ];
+
+    foreach ($candidates as $candidate) {
+        if (is_file($candidate)) {
+            return $candidate;
+        }
+    }
+
+    fwrite(STDERR, 'Unable to locate Composer autoloader.' . PHP_EOL);
+    exit(1);
+};
+
+require $autoload();
+
+$services = new ServiceRegistry();
+$services->freeze();
+
+$application = new CliApplication(new CommandRunner(
+    new CommandRegistry([
+        new DoctorCommand(new EvolveDoctorRunner([
+            new PhpVersionCheck(),
+        ])),
+    ]),
+    new ExecutionOrchestrator($services),
+));
+
+exit($application->run(
+    array_slice($argv, 1),
+    new StreamCommandOutput(STDOUT, STDERR),
+));

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -11,6 +11,9 @@
     "provide": {
         "psr/container-implementation": "1.0.0"
     },
+    "bin": [
+        "bin/evolve"
+    ],
     "autoload": {
         "psr-4": {
             "Evolve\\Core\\": "src/"

--- a/packages/core/src/Console/Runtime/CliApplication.php
+++ b/packages/core/src/Console/Runtime/CliApplication.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Console\Runtime;
+
+use Evolve\Core\Console\CommandInput;
+use Evolve\Core\Console\CommandOutput;
+use Evolve\Core\Console\CommandResult;
+use Evolve\Core\Console\CommandRunner;
+use Evolve\Core\Exception\CommandNotFound;
+use Evolve\Core\Execution\ExecutionOutcome;
+use LogicException;
+
+/**
+ * @internal
+ */
+final readonly class CliApplication
+{
+    public function __construct(
+        private CommandRunner $commands,
+    ) {}
+
+    /**
+     * @param list<string> $arguments
+     */
+    public function run(array $arguments, CommandOutput $output): int
+    {
+        if ($arguments === []) {
+            $output->writeError('No command was specified.');
+
+            return 2;
+        }
+
+        /** @var string $commandName */
+        $commandName = array_shift($arguments);
+
+        try {
+            $outcome = $this->commands->run(
+                $commandName,
+                new CommandInput($arguments),
+                $output,
+            );
+        } catch (CommandNotFound $exception) {
+            $output->writeError($exception->getMessage());
+
+            return 2;
+        }
+
+        return $this->exitCodeFrom($outcome);
+    }
+
+    private function exitCodeFrom(ExecutionOutcome $outcome): int
+    {
+        $cleanupThrowable = $outcome->cleanupThrowable();
+
+        if ($cleanupThrowable !== null) {
+            throw $cleanupThrowable;
+        }
+
+        if ($outcome->primaryFailed()) {
+            throw $outcome->primaryThrowableOrFail();
+        }
+
+        $primaryResult = $outcome->primaryResult();
+
+        if ($primaryResult instanceof CommandResult) {
+            return $primaryResult->exitCode();
+        }
+
+        throw new LogicException('Command runner did not return a command result.');
+    }
+}

--- a/packages/core/src/Console/Runtime/StreamCommandOutput.php
+++ b/packages/core/src/Console/Runtime/StreamCommandOutput.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Console\Runtime;
+
+use Evolve\Core\Console\CommandOutput;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final readonly class StreamCommandOutput implements CommandOutput
+{
+    /**
+     * @param resource $output
+     * @param resource $errorOutput
+     */
+    public function __construct(
+        private mixed $output,
+        private mixed $errorOutput,
+    ) {
+        $this->assertWritableStream($output, 'normal output');
+        $this->assertWritableStream($errorOutput, 'error output');
+    }
+
+    public function write(string $message): void
+    {
+        $this->writeLine($this->output, $message);
+    }
+
+    public function writeError(string $message): void
+    {
+        $this->writeLine($this->errorOutput, $message);
+    }
+
+    /**
+     * @param mixed $stream
+     */
+    private function assertWritableStream(mixed $stream, string $label): void
+    {
+        if (! is_resource($stream) || get_resource_type($stream) !== 'stream') {
+            throw new InvalidArgumentException(sprintf('The %s stream must be a PHP stream resource.', $label));
+        }
+
+        $metadata = stream_get_meta_data($stream);
+        $mode = $metadata['mode'];
+
+        if (strpbrk($mode, 'waxc+') === false) {
+            throw new InvalidArgumentException(sprintf('The %s stream must be writable.', $label));
+        }
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function writeLine(mixed $stream, string $message): void
+    {
+        $line = $message . PHP_EOL;
+        $bytes = fwrite($stream, $line);
+
+        if ($bytes !== strlen($line)) {
+            throw new RuntimeException('Unable to write command output.');
+        }
+    }
+}

--- a/packages/core/tests/Integration/Console/EvolveBinaryTest.php
+++ b/packages/core/tests/Integration/Console/EvolveBinaryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Integration\Console;
+
+use PHPUnit\Framework\TestCase;
+
+final class EvolveBinaryTest extends TestCase
+{
+    public function testDoctorCommandRunsDefaultPhpVersionCheck(): void
+    {
+        $result = $this->runEvolve(['doctor']);
+
+        self::assertSame(0, $result->exitCode);
+        self::assertStringContainsString('[PASS] runtime.php.version:', $result->stdout);
+        self::assertSame('', $result->stderr);
+    }
+
+    public function testDoctorCommandRejectsUnsupportedArguments(): void
+    {
+        $result = $this->runEvolve(['doctor', '--json']);
+
+        self::assertSame(2, $result->exitCode);
+        self::assertStringNotContainsString('[PASS] runtime.php.version:', $result->stdout);
+        self::assertStringContainsString('The doctor command does not accept arguments or options.', $result->stderr);
+    }
+
+    public function testMissingCommandReturnsUsageError(): void
+    {
+        $result = $this->runEvolve(['missing']);
+
+        self::assertSame(2, $result->exitCode);
+        self::assertStringContainsString('Command "missing" was not found.', $result->stderr);
+    }
+
+    public function testNoCommandReturnsUsageError(): void
+    {
+        $result = $this->runEvolve([]);
+
+        self::assertSame(2, $result->exitCode);
+        self::assertStringContainsString('No command was specified.', $result->stderr);
+    }
+
+    /**
+     * @param list<string> $arguments
+     */
+    private function runEvolve(array $arguments): BinaryResult
+    {
+        $binary = dirname(__DIR__, 3) . '/bin/evolve';
+        $command = [PHP_BINARY, $binary, ...$arguments];
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptorSpec, $pipes);
+
+        self::assertIsResource($process);
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return new BinaryResult(
+            proc_close($process),
+            $stdout,
+            $stderr,
+        );
+    }
+}
+
+final readonly class BinaryResult
+{
+    public function __construct(
+        public int $exitCode,
+        public string $stdout,
+        public string $stderr,
+    ) {}
+}

--- a/packages/core/tests/Unit/Console/Runtime/CliApplicationTest.php
+++ b/packages/core/tests/Unit/Console/Runtime/CliApplicationTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Unit\Console\Runtime;
+
+use Closure;
+use Evolve\Core\Console\Command;
+use Evolve\Core\Console\CommandInput;
+use Evolve\Core\Console\CommandOutput;
+use Evolve\Core\Console\CommandRegistry;
+use Evolve\Core\Console\CommandResult;
+use Evolve\Core\Console\CommandRunner;
+use Evolve\Core\Console\Runtime\CliApplication;
+use Evolve\Core\Container\ServiceRegistry;
+use Evolve\Core\Execution\ExecutionIdentifier;
+use Evolve\Core\Execution\ExecutionKind;
+use Evolve\Core\Execution\ExecutionOrchestrator;
+use Evolve\Core\Execution\ExecutionOutcome;
+use Evolve\Core\Instrumentation\Observation;
+use Evolve\Core\Instrumentation\ObservationOutcome;
+use Evolve\Core\Instrumentation\ObservationSink;
+use Evolve\Core\Instrumentation\ObservationType;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use RuntimeException;
+
+final class CliApplicationTest extends TestCase
+{
+    public function testNoCommandReturnsUsageErrorWithoutExecution(): void
+    {
+        $observations = new CollectingObservationSink();
+        $output = new RecordingCommandOutput();
+
+        $exitCode = $this->application([], $observations)->run([], $output);
+
+        self::assertSame(2, $exitCode);
+        self::assertSame([], $output->lines());
+        self::assertSame(['No command was specified.'], $output->errorLines());
+        self::assertSame([], $observations->observations);
+    }
+
+    public function testUnknownCommandReturnsUsageErrorWithoutExecution(): void
+    {
+        $observations = new CollectingObservationSink();
+        $output = new RecordingCommandOutput();
+
+        $exitCode = $this->application([], $observations)->run(['missing'], $output);
+
+        self::assertSame(2, $exitCode);
+        self::assertSame([], $output->lines());
+        self::assertSame(['Command "missing" was not found.'], $output->errorLines());
+        self::assertSame([], $observations->observations);
+    }
+
+    public function testKnownCommandReceivesOnlyTokensAfterCommandName(): void
+    {
+        $receivedTokens = [];
+        $output = new RecordingCommandOutput();
+
+        $exitCode = $this->application([
+            new CallbackCommand(
+                'doctor',
+                static function (CommandInput $input, CommandOutput $_output) use (&$receivedTokens): CommandResult {
+                    $receivedTokens = $input->tokens();
+
+                    return new CommandResult(0);
+                },
+            ),
+        ])->run(['doctor', 'foo', 'bar'], $output);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(['foo', 'bar'], $receivedTokens);
+    }
+
+    public function testKnownSuccessfulCommandResultReturnsZero(): void
+    {
+        $exitCode = $this->application([
+            new CallbackCommand(
+                'doctor',
+                static fn(CommandInput $_input, CommandOutput $_output): CommandResult => new CommandResult(0),
+            ),
+        ])->run(['doctor'], new RecordingCommandOutput());
+
+        self::assertSame(0, $exitCode);
+    }
+
+    public function testKnownNonZeroCommandResultIsReturnedUnchanged(): void
+    {
+        $exitCode = $this->application([
+            new CallbackCommand(
+                'doctor',
+                static fn(CommandInput $_input, CommandOutput $_output): CommandResult => new CommandResult(1),
+            ),
+        ])->run(['doctor'], new RecordingCommandOutput());
+
+        self::assertSame(1, $exitCode);
+    }
+
+    public function testNonZeroCommandResultRemainsSuccessfulFrameworkExecution(): void
+    {
+        $observations = new CollectingObservationSink();
+
+        $exitCode = $this->application([
+            new CallbackCommand(
+                'doctor',
+                static fn(CommandInput $_input, CommandOutput $_output): CommandResult => new CommandResult(1),
+            ),
+        ], $observations)->run(['doctor'], new RecordingCommandOutput());
+
+        self::assertSame(1, $exitCode);
+        $this->assertObservedCliCommandLifecycle($observations);
+
+        $handlerCompleted = null;
+
+        foreach ($observations->observations as $observation) {
+            if ($observation->type() === ObservationType::HandlerCompleted) {
+                $handlerCompleted = $observation;
+
+                break;
+            }
+        }
+
+        self::assertNotNull($handlerCompleted);
+        self::assertSame(
+            ObservationOutcome::Succeeded,
+            $handlerCompleted->outcome(),
+        );
+    }
+
+    public function testPrimaryCommandThrowablePropagatesWhenCleanupSucceeds(): void
+    {
+        $throwable = new RuntimeException('primary failure');
+
+        $this->expectExceptionObject($throwable);
+
+        $this->application([
+            new CallbackCommand(
+                'doctor',
+                static function (
+                    CommandInput $_input,
+                    CommandOutput $_output,
+                ) use ($throwable): CommandResult {
+                    throw $throwable;
+                },
+            ),
+        ])->run(['doctor'], new RecordingCommandOutput());
+    }
+
+    public function testCleanupFailureIsNotHiddenBehindCommandResult(): void
+    {
+        $throwable = new RuntimeException('cleanup failure');
+
+        $outcome = ExecutionOutcome::succeeded(
+            ExecutionIdentifier::generate(),
+            ExecutionKind::CliCommand,
+            new CommandResult(0),
+            $throwable,
+        );
+
+        $this->expectExceptionObject($throwable);
+
+        $this->exitCodeFrom($outcome);
+    }
+
+    public function testCleanupFailureTakesPrecedenceOverPrimaryFailure(): void
+    {
+        $primaryThrowable = new RuntimeException('primary failure');
+        $cleanupThrowable = new RuntimeException('cleanup failure');
+
+        $outcome = ExecutionOutcome::failed(
+            ExecutionIdentifier::generate(),
+            ExecutionKind::CliCommand,
+            $primaryThrowable,
+            $cleanupThrowable,
+        );
+
+        $this->expectExceptionObject($cleanupThrowable);
+
+        $this->exitCodeFrom($outcome);
+    }
+
+    public function testExecutionRemainsCliCommandThroughExistingRunnerLifecycle(): void
+    {
+        $observations = new CollectingObservationSink();
+
+        $this->application([
+            new CallbackCommand(
+                'doctor',
+                static fn(CommandInput $_input, CommandOutput $_output): CommandResult => new CommandResult(0),
+            ),
+        ], $observations)->run(['doctor'], new RecordingCommandOutput());
+
+        $this->assertObservedCliCommandLifecycle($observations);
+    }
+
+    /**
+     * @param list<Command> $commands
+     */
+    private function application(
+        array $commands,
+        ?ObservationSink $sink = null,
+    ): CliApplication {
+        $registry = new ServiceRegistry();
+        $registry->freeze();
+
+        return new CliApplication(new CommandRunner(
+            new CommandRegistry($commands),
+            new ExecutionOrchestrator($registry, $sink),
+        ));
+    }
+
+    private function exitCodeFrom(ExecutionOutcome $outcome): int
+    {
+        $application = $this->application([]);
+        $method = new ReflectionMethod(CliApplication::class, 'exitCodeFrom');
+
+        $result = $method->invoke($application, $outcome);
+
+        self::assertIsInt($result);
+
+        return $result;
+    }
+
+    private function assertObservedCliCommandLifecycle(
+        CollectingObservationSink $observations,
+    ): void {
+        self::assertNotSame([], $observations->observations);
+
+        foreach ($observations->observations as $observation) {
+            self::assertSame(
+                ExecutionKind::CliCommand,
+                $observation->kind(),
+            );
+        }
+    }
+}
+
+final readonly class CallbackCommand implements Command
+{
+    /**
+     * @param Closure(CommandInput, CommandOutput): CommandResult $callback
+     */
+    public function __construct(
+        private string $name,
+        private Closure $callback,
+    ) {}
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function description(): string
+    {
+        return 'Test command.';
+    }
+
+    public function execute(
+        CommandInput $input,
+        CommandOutput $output,
+    ): CommandResult {
+        return ($this->callback)($input, $output);
+    }
+}
+
+final class CollectingObservationSink implements ObservationSink
+{
+    /** @var list<Observation> */
+    public array $observations = [];
+
+    public function observe(Observation $observation): void
+    {
+        $this->observations[] = $observation;
+    }
+}
+
+final class RecordingCommandOutput implements CommandOutput
+{
+    /** @var list<string> */
+    private array $lines = [];
+
+    /** @var list<string> */
+    private array $errorLines = [];
+
+    public function write(string $message): void
+    {
+        $this->lines[] = $message;
+    }
+
+    public function writeError(string $message): void
+    {
+        $this->errorLines[] = $message;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function lines(): array
+    {
+        return $this->lines;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function errorLines(): array
+    {
+        return $this->errorLines;
+    }
+}

--- a/packages/core/tests/Unit/Console/Runtime/StreamCommandOutputTest.php
+++ b/packages/core/tests/Unit/Console/Runtime/StreamCommandOutputTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Evolve\Core\Tests\Unit\Console\Runtime;
+
+use Evolve\Core\Console\Runtime\StreamCommandOutput;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class StreamCommandOutputTest extends TestCase
+{
+    public function testWriteWritesToNormalStreamOnly(): void
+    {
+        $normal = fopen('php://temp', 'w+');
+        $error = fopen('php://temp', 'w+');
+        $output = new StreamCommandOutput($normal, $error);
+
+        $output->write('hello');
+
+        self::assertSame('hello' . PHP_EOL, $this->contents($normal));
+        self::assertSame('', $this->contents($error));
+    }
+
+    public function testWriteErrorWritesToErrorStreamOnly(): void
+    {
+        $normal = fopen('php://temp', 'w+');
+        $error = fopen('php://temp', 'w+');
+        $output = new StreamCommandOutput($normal, $error);
+
+        $output->writeError('problem');
+
+        self::assertSame('', $this->contents($normal));
+        self::assertSame('problem' . PHP_EOL, $this->contents($error));
+    }
+
+    public function testWriteAddsExactlyOneLineEnding(): void
+    {
+        $normal = fopen('php://temp', 'w+');
+        $error = fopen('php://temp', 'w+');
+        $output = new StreamCommandOutput($normal, $error);
+
+        $output->write('hello');
+
+        self::assertSame('hello' . PHP_EOL, $this->contents($normal));
+    }
+
+    public function testWriteErrorAddsExactlyOneLineEnding(): void
+    {
+        $normal = fopen('php://temp', 'w+');
+        $error = fopen('php://temp', 'w+');
+        $output = new StreamCommandOutput($normal, $error);
+
+        $output->writeError('problem');
+
+        self::assertSame('problem' . PHP_EOL, $this->contents($error));
+    }
+
+    public function testOrderedRepeatedWritesRemainOrdered(): void
+    {
+        $normal = fopen('php://temp', 'w+');
+        $error = fopen('php://temp', 'w+');
+        $output = new StreamCommandOutput($normal, $error);
+
+        $output->write('first');
+        $output->write('second');
+        $output->writeError('third');
+        $output->writeError('fourth');
+
+        self::assertSame('first' . PHP_EOL . 'second' . PHP_EOL, $this->contents($normal));
+        self::assertSame('third' . PHP_EOL . 'fourth' . PHP_EOL, $this->contents($error));
+    }
+
+    public function testInvalidNormalStreamFailsFast(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $class = new ReflectionClass(StreamCommandOutput::class);
+
+        $class->newInstanceArgs([
+            'not-a-stream',
+            fopen('php://temp', 'w+'),
+        ]);
+    }
+
+    public function testInvalidErrorStreamFailsFast(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $class = new ReflectionClass(StreamCommandOutput::class);
+
+        $class->newInstanceArgs([
+            fopen('php://temp', 'w+'),
+            'not-a-stream',
+        ]);
+    }
+
+    public function testReadOnlyNormalStreamFailsFast(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new StreamCommandOutput(fopen(__FILE__, 'r'), fopen('php://temp', 'w+'));
+    }
+
+    public function testReadOnlyErrorStreamFailsFast(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new StreamCommandOutput(fopen('php://temp', 'w+'), fopen(__FILE__, 'r'));
+    }
+
+    public function testInjectedStreamsAreNotClosed(): void
+    {
+        $normal = fopen('php://temp', 'w+');
+        $error = fopen('php://temp', 'w+');
+        $output = new StreamCommandOutput($normal, $error);
+
+        $output->write('hello');
+        $output->writeError('problem');
+        unset($output);
+
+        self::assertTrue(is_resource($normal));
+        self::assertTrue(is_resource($error));
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function contents($stream): string
+    {
+        rewind($stream);
+
+        return stream_get_contents($stream);
+    }
+}

--- a/tests/Architecture/EvolvePhp2PackageSkeletonTest.php
+++ b/tests/Architecture/EvolvePhp2PackageSkeletonTest.php
@@ -4,6 +4,32 @@ use PHPUnit\Framework\TestCase;
 
 final class EvolvePhp2PackageSkeletonTest extends TestCase
 {
+    public function testCorePackageExposesOnlyEvolveBinary(): void
+    {
+        self::assertFileExists(dirname(__DIR__, 2) . '/packages/core/bin/evolve');
+
+        $manifest = json_decode(
+            file_get_contents(dirname(__DIR__, 2) . '/packages/core/composer.json'),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        self::assertSame(['bin/evolve'], $manifest['bin'] ?? null);
+    }
+
+    public function testOnlyCorePackageExposesComposerBinary(): void
+    {
+        foreach (['contracts', 'http', 'module', 'plugin', 'testing'] as $package) {
+            $manifest = json_decode(
+                file_get_contents(dirname(__DIR__, 2) . sprintf('/packages/%s/composer.json', $package)),
+                true,
+                flags: JSON_THROW_ON_ERROR,
+            );
+
+            self::assertArrayNotHasKey('bin', $manifest);
+        }
+    }
+
     private $root;
 
     protected function setUp(): void
@@ -756,6 +782,8 @@ final class EvolvePhp2PackageSkeletonTest extends TestCase
             'Console/CommandRegistry.php',
             'Console/CommandResult.php',
             'Console/CommandRunner.php',
+            'Console/Runtime/CliApplication.php',
+            'Console/Runtime/StreamCommandOutput.php',
                 'Container/ExecutionScopeContainer.php',
                 'Container/ServiceContainer.php',
                 'Container/ServiceDefinition.php',


### PR DESCRIPTION
## Summary

Adds the first package-owned Evolve CLI entrypoint and wires the existing Doctor command through the Core console execution lifecycle.

## Changes

- expose `bin/evolve` from `evolvephp/core` through Composer
- add argv-to-command runtime wiring with explicit usage and error handling
- add stdout/stderr stream-backed command output
- wire `doctor` through `CommandRunner` and the existing execution orchestrator
- run the default PHP version Doctor check from the shell entrypoint
- add unit, integration, architecture, and package-metadata coverage
- document current CLI behavior and limitations

## Validation

- full quality suite: 572 tests, 2,128 assertions
- PHPStan: clean
- PHP CS Fixer: clean
- Composer validation: clean
- security and supply-chain checks: clean
- release consumer validation: clean
- deterministic package split validation: clean
- both `vendor/bin/evolve doctor` and `packages/core/bin/evolve doctor` pass

## Current limits

This does not add option parsing, help/list/completion, JSON Doctor output, project or Composer inspection, extension discovery, route/environment/writable-path checks, generators, or interactive/TTY/ANSI behavior.